### PR TITLE
chore: add mapper for top-level SDK Config

### DIFF
--- a/apikeys/client.go
+++ b/apikeys/client.go
@@ -45,12 +45,7 @@ type Client struct {
 // NewClient creates a new API keys client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/available/client.go
+++ b/available/client.go
@@ -17,12 +17,7 @@ type Client struct {
 // NewClient creates a new available client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg: cfg.ToRequestConfig(),
 	}
 }
 

--- a/bankaccounts/client.go
+++ b/bankaccounts/client.go
@@ -242,12 +242,7 @@ type Client struct {
 // NewClient creates a new bank accounts client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/instances/client.go
+++ b/instances/client.go
@@ -55,12 +55,7 @@ type Client struct {
 // NewClient creates a new instances client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,36 @@
 package config
 
-import "net/http"
+import (
+	"net/http"
 
+	"github.com/blindpaylabs/blindpay-go/internal/request"
+)
+
+/*
+Config holds the top-level configuration required to initialize Blindpay SDK clients.
+It may include both transport-level fields and the instance identifier used to compose API paths.
+*/
 type Config struct {
 	BaseURL    string
 	APIKey     string
 	InstanceID string
 	HTTPClient *http.Client
 	UserAgent  string
+}
+
+/*
+Converts the top-level Config into the transport/request layer config used by internal HTTP helpers.
+This reduces coupling between the transport layer and higher-level SDK components.
+*/
+func (c *Config) ToRequestConfig() *request.Config {
+	if c == nil {
+		return nil
+	}
+
+	return &request.Config{
+		BaseURL:    c.BaseURL,
+		APIKey:     c.APIKey,
+		HTTPClient: c.HTTPClient,
+		UserAgent:  c.UserAgent,
+	}
 }

--- a/partnerfees/client.go
+++ b/partnerfees/client.go
@@ -42,12 +42,7 @@ type Client struct {
 // NewClient creates a new partner fees client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/payins/client.go
+++ b/payins/client.go
@@ -117,12 +117,7 @@ type Client struct {
 
 // NewClient creates a new payins client.
 func NewClient(cfg *config.Config) *Client {
-	reqCfg := &request.Config{
-		BaseURL:    cfg.BaseURL,
-		APIKey:     cfg.APIKey,
-		HTTPClient: cfg.HTTPClient,
-		UserAgent:  cfg.UserAgent,
-	}
+	reqCfg := cfg.ToRequestConfig()
 
 	return &Client{
 		cfg:        reqCfg,

--- a/payins/quotes_test.go
+++ b/payins/quotes_test.go
@@ -60,12 +60,7 @@ func TestQuotesClient_Create(t *testing.T) {
 	}
 
 	client := &QuotesClient{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: instanceID,
 	}
 
@@ -144,12 +139,7 @@ func TestQuotesClient_Create_WithPartnerFee(t *testing.T) {
 	}
 
 	client := &QuotesClient{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: instanceID,
 	}
 
@@ -224,12 +214,7 @@ func TestQuotesClient_GetFxRate(t *testing.T) {
 	}
 
 	client := &QuotesClient{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: instanceID,
 	}
 
@@ -287,12 +272,7 @@ func TestQuotesClient_GetFxRate_ReceiverCurrency(t *testing.T) {
 	}
 
 	client := &QuotesClient{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: instanceID,
 	}
 

--- a/payouts/client.go
+++ b/payouts/client.go
@@ -142,12 +142,7 @@ type Client struct {
 // NewClient creates a new payouts client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/quotes/client.go
+++ b/quotes/client.go
@@ -78,12 +78,7 @@ type Client struct {
 // NewClient creates a new quotes client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/receivers/client.go
+++ b/receivers/client.go
@@ -366,12 +366,7 @@ type Client struct {
 // NewClient creates a new receivers client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/virtualaccounts/client.go
+++ b/virtualaccounts/client.go
@@ -68,12 +68,7 @@ type Client struct {
 // NewClient creates a new virtual accounts client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/wallets/client.go
+++ b/wallets/client.go
@@ -63,12 +63,7 @@ type Client struct {
 // NewClient creates a new wallets client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }
@@ -237,12 +232,7 @@ type OfframpClient struct {
 // NewOfframpClient creates a new offramp wallets client.
 func NewOfframpClient(cfg *config.Config) *OfframpClient {
 	return &OfframpClient{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }

--- a/webhookendpoints/client.go
+++ b/webhookendpoints/client.go
@@ -51,12 +51,7 @@ type Client struct {
 // NewClient creates a new webhook endpoints client.
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
-		cfg: &request.Config{
-			BaseURL:    cfg.BaseURL,
-			APIKey:     cfg.APIKey,
-			HTTPClient: cfg.HTTPClient,
-			UserAgent:  cfg.UserAgent,
-		},
+		cfg:        cfg.ToRequestConfig(),
 		instanceID: cfg.InstanceID,
 	}
 }


### PR DESCRIPTION
**Summary:**

- Introduce a top-level SDK Config and a helper ToRequestConfig that translates it into the transport/request layer config.
- Centralize HTTP-related options (HTTPClient, UserAgent) alongside API credentials.

**What changed:**

- Added Config struct with BaseURL, APIKey, HTTPClient, and UserAgent.
- Implemented ToRequestConfig to convert Config into request.Config for internal HTTP helpers.

**Why:**

- Reduce coupling between higher-level SDK components and the transport layer.
- Provide a single source of truth for SDK configuration.
- Make it easier to instantiate clients and pass only transport-relevant fields to the request layer.
- Prepare for instance-aware API path composition at higher layers (via InstanceID), without leaking that concern into the transport layer.

**Behavior/compatibility:**

- Low risk, additive change.
- ToRequestConfig returns nil when called on a nil receiver.
- No breaking changes to existing request helpers; this is a focused mapping utility.

**Next steps (follow-ups):**

- Adopt ToRequestConfig in client initialization paths.
- Optionally add validation/defaulting (e.g., required fields, trimming trailing slashes) in a future PR.

Please feel free to reach me out at Github or lucasarieta@gmail.com
