### PR TITLE
fix: change BankAccountTypeSaving enum value from 'savings' to 'saving'

### DIFF
--- a/internal/types/shared.go
+++ b/internal/types/shared.go
@@ -49,7 +49,7 @@ type BankAccountType string
 
 const (
 	BankAccountTypeChecking BankAccountType = "checking"
-	BankAccountTypeSavings  BankAccountType = "savings"
+	BankAccountTypeSaving   BankAccountType = "saving"
 )
 
 type Currency string

--- a/types.go
+++ b/types.go
@@ -42,7 +42,7 @@ const (
 	TransactionDocumentOthers             = types.TransactionDocumentTypeOthers
 
 	BankAccountTypeChecking = types.BankAccountTypeChecking
-	BankAccountTypeSavings  = types.BankAccountTypeSavings
+	BankAccountTypeSaving   = types.BankAccountTypeSaving
 
 	CurrencyUSDC = types.CurrencyUSDC
 	CurrencyUSDT = types.CurrencyUSDT


### PR DESCRIPTION
## Summary
Fixes the bank account type enum value for savings accounts.

## Problem
The API expects `'saving'` (without the 's') but the we were sending `'savings'`, causing this error:
```
Invalid enum value. Expected 'checking' | 'saving', received 'savings'
```

## Changes
- Changed `BankAccountTypeSavings` to `BankAccountTypeSaving`
- Changed the value from `"savings"` to `"saving"`

## Breaking Change 
Users currently using `BankAccountTypeSavings` will need to update their code to use `BankAccountTypeSaving`.

## Version
This should be released as `v2.2.0`