### PR TITLE
fix: restore TOS endpoints

### DIFF
--- a/blindpay.go
+++ b/blindpay.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blindpaylabs/blindpay-go/payouts"
 	"github.com/blindpaylabs/blindpay-go/quotes"
 	"github.com/blindpaylabs/blindpay-go/receivers"
+	"github.com/blindpaylabs/blindpay-go/termsofservice"
 	"github.com/blindpaylabs/blindpay-go/transfers"
 	"github.com/blindpaylabs/blindpay-go/upload"
 	"github.com/blindpaylabs/blindpay-go/virtualaccounts"
@@ -25,7 +26,7 @@ import (
 )
 
 // Version is the current version of the SDK.
-const Version = "1.10.0"
+const Version = "1.11.0"
 
 // Client is the main BlindPay client.
 type Client struct {
@@ -45,6 +46,7 @@ type Client struct {
 	Payouts          *payouts.Client
 	Quotes           *quotes.Client
 	Receivers        *receivers.Client
+	Tos              *termsofservice.Client
 	Transfers        *transfers.Client
 	Upload           *upload.Client
 	VirtualAccounts  *virtualaccounts.Client
@@ -95,6 +97,7 @@ func New(apiKey, instanceID string, opts ...Option) (*Client, error) {
 	c.Payouts = payouts.NewClient(cfg)
 	c.Quotes = quotes.NewClient(cfg)
 	c.Receivers = receivers.NewClient(cfg)
+	c.Tos = termsofservice.NewClient(cfg)
 	c.Transfers = transfers.NewClient(cfg)
 	c.Upload = upload.NewClient(cfg)
 	c.VirtualAccounts = virtualaccounts.NewClient(cfg)

--- a/termsofservice/client.go
+++ b/termsofservice/client.go
@@ -1,0 +1,48 @@
+package termsofservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blindpaylabs/blindpay-go/internal/config"
+	"github.com/blindpaylabs/blindpay-go/internal/request"
+)
+
+// InitiateParams represents parameters for initiating terms of service.
+type InitiateParams struct {
+	IdempotencyKey string  `json:"idempotency_key"`
+	ReceiverID     *string `json:"receiver_id"`
+	RedirectURL    *string `json:"redirect_url"`
+}
+
+// InitiateResponse represents the response from initiating terms of service.
+type InitiateResponse struct {
+	URL string `json:"url"`
+}
+
+// Client handles terms of service-related operations.
+type Client struct {
+	cfg        *request.Config
+	instanceID string
+}
+
+// NewClient creates a new terms of service client.
+func NewClient(cfg *config.Config) *Client {
+	return &Client{
+		cfg:        cfg.ToRequestConfig(),
+		instanceID: cfg.InstanceID,
+	}
+}
+
+// Initiate initiates the terms of service flow and returns a URL.
+func (c *Client) Initiate(ctx context.Context, params *InitiateParams) (*InitiateResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+	if params.IdempotencyKey == "" {
+		return nil, fmt.Errorf("idempotency key cannot be empty")
+	}
+
+	path := fmt.Sprintf("/e/instances/%s/tos", c.instanceID)
+	return request.Do[*InitiateResponse](c.cfg, ctx, "POST", path, params)
+}

--- a/termsofservice/termsofservice_test.go
+++ b/termsofservice/termsofservice_test.go
@@ -1,0 +1,50 @@
+package termsofservice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/blindpaylabs/blindpay-go/internal/blindpaytest"
+	"github.com/blindpaylabs/blindpay-go/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTermsOfService_Initiate(t *testing.T) {
+	instanceID := "in_000000000000"
+	idempotencyKey := "123e4567-e89b-12d3-a456-426614174000"
+	url := "https://app.blindpay.com/e/terms-of-service?session_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test-key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				In: json.RawMessage(`{
+					"idempotency_key":"123e4567-e89b-12d3-a456-426614174000",
+					"receiver_id":null,
+					"redirect_url":null
+				}`),
+				Out: json.RawMessage(`{
+					"url":"https://app.blindpay.com/e/terms-of-service?session_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+				}`),
+				Method: http.MethodPost,
+				Path:   fmt.Sprintf("/e/instances/%s/tos", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	response, err := client.Initiate(context.Background(), &InitiateParams{
+		IdempotencyKey: idempotencyKey,
+		ReceiverID:     nil,
+		RedirectURL:    nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, url, response.URL)
+}


### PR DESCRIPTION
## Summary
- Restores the `termsofservice` package (`client.go` + `termsofservice_test.go`) that was accidentally deleted in commit `2e920be`
- Wires the TOS client back into the main `blindpay.Client` struct as the `Tos` field
- Updates the TOS `NewClient` constructor to use `cfg.ToRequestConfig()` (consistent with all other sub-clients)
- Bumps SDK version from `1.10.0` to `1.11.0`

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (including `termsofservice` test)
- [x] `gofmt` applied with no changes needed