### PR TITLE
feat: add customers resource, deprecate receivers (v1.14.0)

### DIFF
--- a/bankaccounts/bankaccounts_test.go
+++ b/bankaccounts/bankaccounts_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestBankAccounts_CreatePix(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -37,7 +37,7 @@ func TestBankAccounts_CreatePix(t *testing.T) {
 					"created_at": "2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -45,7 +45,7 @@ func TestBankAccounts_CreatePix(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreatePix(context.Background(), &CreatePixParams{
-		ReceiverID: receiverID,
+		CustomerID: customerID,
 		Name:       "PIX Account",
 		PixKey:     "14947677768",
 	})
@@ -57,7 +57,7 @@ func TestBankAccounts_CreatePix(t *testing.T) {
 
 func TestBankAccounts_CreateArgentinaTransfers(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -83,7 +83,7 @@ func TestBankAccounts_CreateArgentinaTransfers(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -91,7 +91,7 @@ func TestBankAccounts_CreateArgentinaTransfers(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateArgentinaTransfers(context.Background(), &CreateArgentinaTransfersParams{
-		ReceiverID:       receiverID,
+		CustomerID:       customerID,
 		Name:             "Argentina Transfers Account",
 		BeneficiaryName:  "Individual full name or business name",
 		TransfersType:    ArgentinaTransfersCVU,
@@ -103,7 +103,7 @@ func TestBankAccounts_CreateArgentinaTransfers(t *testing.T) {
 
 func TestCreateSpei(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -131,7 +131,7 @@ func TestCreateSpei(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -139,7 +139,7 @@ func TestCreateSpei(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateSpei(context.Background(), &CreateSpeiParams{
-		ReceiverID:          receiverID,
+		CustomerID:          customerID,
 		BeneficiaryName:     "Individual full name or business name",
 		Name:                "SPEI Account",
 		SpeiClabe:           "5482347403740546",
@@ -152,7 +152,7 @@ func TestCreateSpei(t *testing.T) {
 
 func TestCreateColombiaAch(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -188,7 +188,7 @@ func TestCreateColombiaAch(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -196,7 +196,7 @@ func TestCreateColombiaAch(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateColombiaAch(context.Background(), &CreateColombiaAchParams{
-		ReceiverID:                 receiverID,
+		CustomerID:                 customerID,
 		Name:                       "Colombia ACH Account",
 		AccountType:                types.BankAccountTypeChecking,
 		AchCopBeneficiaryFirstName: "Fernando",
@@ -213,7 +213,7 @@ func TestCreateColombiaAch(t *testing.T) {
 
 func TestCreateAch(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -262,7 +262,7 @@ func TestCreateAch(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -270,7 +270,7 @@ func TestCreateAch(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateAch(context.Background(), &CreateAchParams{
-		ReceiverID:            receiverID,
+		CustomerID:            customerID,
 		Name:                  "ACH Account",
 		AccountClass:          types.AccountClassIndividual,
 		AccountNumber:         "1001001234",
@@ -290,7 +290,7 @@ func TestCreateAch(t *testing.T) {
 
 func TestCreateWire(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -330,7 +330,7 @@ func TestCreateWire(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -338,7 +338,7 @@ func TestCreateWire(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateWire(context.Background(), &CreateWireParams{
-		ReceiverID:            receiverID,
+		CustomerID:            customerID,
 		Name:                  "Wire Account",
 		AccountClass:          types.AccountClassIndividual,
 		AccountNumber:         "1001001234",
@@ -358,7 +358,7 @@ func TestCreateWire(t *testing.T) {
 
 func TestCreateInternationalSwift(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -425,7 +425,7 @@ func TestCreateInternationalSwift(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -433,7 +433,7 @@ func TestCreateInternationalSwift(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateInternationalSwift(context.Background(), &CreateInternationalSwiftParams{
-		ReceiverID:                             receiverID,
+		CustomerID:                             customerID,
 		Name:                                   "International Swift Account",
 		AccountClass:                           types.AccountClassIndividual,
 		RecipientRelationship:                  types.RecipientRelationshipFirstParty,
@@ -462,7 +462,7 @@ func TestCreateInternationalSwift(t *testing.T) {
 
 func TestBankAccounts_CreateRtp(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -501,7 +501,7 @@ func TestBankAccounts_CreateRtp(t *testing.T) {
 					"created_at":"2025-09-30T04:23:30.823Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -509,7 +509,7 @@ func TestBankAccounts_CreateRtp(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.CreateRtp(context.Background(), &CreateRtpParams{
-		ReceiverID:            receiverID,
+		CustomerID:            customerID,
 		Name:                  "John Doe RTP",
 		AccountClass:          types.AccountClassIndividual,
 		BeneficiaryName:       "John Doe",
@@ -528,7 +528,7 @@ func TestBankAccounts_CreateRtp(t *testing.T) {
 
 func TestBankAccounts_Get(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	id := "ba_000000000000"
 
 	cfg := &config.Config{
@@ -540,7 +540,7 @@ func TestBankAccounts_Get(t *testing.T) {
 				T: t,
 				Out: json.RawMessage(`{
 					"id":"ba_000000000000",
-					"receiver_id":"rcv_123",
+					"customer_id":"rcv_123",
 					"account_holder_name":"Individual full name or business name",
 					"account_number":"1001001234",
 					"routing_number":"012345678",
@@ -553,22 +553,22 @@ func TestBankAccounts_Get(t *testing.T) {
 					"updated_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s", instanceID, receiverID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s", instanceID, customerID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	account, err := client.Get(context.Background(), receiverID, id)
+	account, err := client.Get(context.Background(), customerID, id)
 	require.NoError(t, err)
 	require.Equal(t, "ba_000000000000", account.ID)
-	require.Equal(t, "rcv_123", account.ReceiverID)
+	require.Equal(t, "rcv_123", account.CustomerID)
 }
 
 func TestBankAccounts_List(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	mockOut := `[
 		{
@@ -641,14 +641,14 @@ func TestBankAccounts_List(t *testing.T) {
 				T:      t,
 				Out:    json.RawMessage(mockOut),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	bankAccounts, err := client.List(context.Background(), &ListParams{ReceiverID: receiverID})
+	bankAccounts, err := client.List(context.Background(), &ListParams{CustomerID: customerID})
 	require.NoError(t, err)
 	require.Len(t, bankAccounts, 1)
 	require.Equal(t, "ba_000000000000", bankAccounts[0].ID)
@@ -656,7 +656,7 @@ func TestBankAccounts_List(t *testing.T) {
 
 func TestBankAccounts_Delete(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	id := "ba_000000000000"
 
 	cfg := &config.Config{
@@ -668,13 +668,13 @@ func TestBankAccounts_Delete(t *testing.T) {
 				T:      t,
 				Out:    json.RawMessage(`{"data": null}`),
 				Method: http.MethodDelete,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s", instanceID, receiverID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s", instanceID, customerID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	err := client.Delete(context.Background(), receiverID, id)
+	err := client.Delete(context.Background(), customerID, id)
 	require.NoError(t, err)
 }

--- a/bankaccounts/client.go
+++ b/bankaccounts/client.go
@@ -94,6 +94,7 @@ type BankAccount struct {
 	TedBankCode                            *string               `json:"ted_bank_code,omitempty"`
 	TedBranchCode                          *string               `json:"ted_branch_code,omitempty"`
 	TedCpfCnpj                             *string               `json:"ted_cpf_cnpj,omitempty"`
+	SepaBeneficiaryBic                     *string               `json:"sepa_beneficiary_bic,omitempty"`
 	CreatedAt                              time.Time             `json:"created_at"`
 }
 
@@ -117,6 +118,7 @@ type GetResponse struct {
 	SwiftCode         *string               `json:"swift_code"`
 	IBAN              *string               `json:"iban"`
 	IsPrimary         bool                  `json:"is_primary"`
+	SepaBeneficiaryBic *string               `json:"sepa_beneficiary_bic,omitempty"`
 	CreatedAt         time.Time             `json:"created_at"`
 	UpdatedAt         time.Time             `json:"updated_at"`
 }
@@ -257,6 +259,7 @@ type CreateInternationalSwiftResponse struct {
 	SwiftIntermediaryBankName              *string                     `json:"swift_intermediary_bank_name"`
 	SwiftIntermediaryBankCountry           *types.Country              `json:"swift_intermediary_bank_country"`
 	SwiftPaymentCode                       *string                     `json:"swift_payment_code"`
+	SepaBeneficiaryBic                     *string                     `json:"sepa_beneficiary_bic,omitempty"`
 	CreatedAt                              time.Time                   `json:"created_at"`
 }
 
@@ -464,6 +467,7 @@ type CreateInternationalSwiftParams struct {
 	PhoneNumber                            string                      `json:"phone_number,omitempty"`
 	TaxID                                  string                      `json:"tax_id,omitempty"`
 	DateOfBirth                            string                      `json:"date_of_birth,omitempty"`
+	SepaBeneficiaryBic                     *string                     `json:"sepa_beneficiary_bic,omitempty"`
 }
 
 // CreateRtpParams represents parameters for creating an RTP (Real-Time Payments) bank account.
@@ -802,6 +806,9 @@ func (c *Client) CreateInternationalSwift(ctx context.Context, params *CreateInt
 	if params.DateOfBirth != "" {
 		body["date_of_birth"] = params.DateOfBirth
 	}
+	if params.SepaBeneficiaryBic != nil {
+		body["sepa_beneficiary_bic"] = params.SepaBeneficiaryBic
+	}
 
 	return request.Do[*CreateInternationalSwiftResponse](c.cfg, ctx, "POST", path, body)
 }
@@ -920,4 +927,73 @@ func (c *Client) CreateTed(ctx context.Context, params *CreateTedParams) (*Creat
 	}
 
 	return request.Do[*CreateTedResponse](c.cfg, ctx, "POST", path, body)
+}
+
+// CreateSepaParams represents parameters for creating a SEPA bank account.
+type CreateSepaParams struct {
+	CustomerID                        string                `json:"-"`
+	Name                              string                `json:"name"`
+	AccountClass                      types.AccountClass    `json:"account_class"`
+	SepaIban                          string                `json:"sepa_iban"`
+	SepaBeneficiaryBic                string                `json:"sepa_beneficiary_bic"`
+	SepaBeneficiaryLegalName          string                `json:"sepa_beneficiary_legal_name"`
+	SepaBeneficiaryAddressLine1       string                `json:"sepa_beneficiary_address_line_1"`
+	SepaBeneficiaryAddressLine2       *string               `json:"sepa_beneficiary_address_line_2,omitempty"`
+	SepaBeneficiaryCity               string                `json:"sepa_beneficiary_city"`
+	SepaBeneficiaryStateProvinceRegion *string              `json:"sepa_beneficiary_state_province_region,omitempty"`
+	SepaBeneficiaryPostalCode         string                `json:"sepa_beneficiary_postal_code"`
+	SepaBeneficiaryCountry            types.Country         `json:"sepa_beneficiary_country"`
+}
+
+// CreateSepaResponse represents the response when creating a SEPA bank account.
+type CreateSepaResponse struct {
+	ID                                 string                       `json:"id"`
+	Type                               string                       `json:"type"`
+	Name                               string                       `json:"name"`
+	AccountClass                       types.AccountClass           `json:"account_class"`
+	RecipientRelationship              *types.RecipientRelationship `json:"recipient_relationship"`
+	SepaIban                           string                       `json:"sepa_iban"`
+	SepaBeneficiaryBic                 string                       `json:"sepa_beneficiary_bic"`
+	SepaBeneficiaryLegalName           string                       `json:"sepa_beneficiary_legal_name"`
+	SepaBeneficiaryAddressLine1        string                       `json:"sepa_beneficiary_address_line_1"`
+	SepaBeneficiaryAddressLine2        *string                      `json:"sepa_beneficiary_address_line_2"`
+	SepaBeneficiaryCity                string                       `json:"sepa_beneficiary_city"`
+	SepaBeneficiaryStateProvinceRegion *string                      `json:"sepa_beneficiary_state_province_region"`
+	SepaBeneficiaryPostalCode          string                       `json:"sepa_beneficiary_postal_code"`
+	SepaBeneficiaryCountry             types.Country                `json:"sepa_beneficiary_country"`
+	CreatedAt                          time.Time                    `json:"created_at"`
+}
+
+// CreateSepa creates a SEPA bank account.
+func (c *Client) CreateSepa(ctx context.Context, params *CreateSepaParams) (*CreateSepaResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
+
+	body := map[string]any{
+		"type":                            "sepa",
+		"name":                            params.Name,
+		"account_class":                   params.AccountClass,
+		"sepa_iban":                       params.SepaIban,
+		"sepa_beneficiary_bic":            params.SepaBeneficiaryBic,
+		"sepa_beneficiary_legal_name":     params.SepaBeneficiaryLegalName,
+		"sepa_beneficiary_address_line_1": params.SepaBeneficiaryAddressLine1,
+		"sepa_beneficiary_city":           params.SepaBeneficiaryCity,
+		"sepa_beneficiary_postal_code":    params.SepaBeneficiaryPostalCode,
+		"sepa_beneficiary_country":        params.SepaBeneficiaryCountry,
+	}
+
+	if params.SepaBeneficiaryAddressLine2 != nil {
+		body["sepa_beneficiary_address_line_2"] = *params.SepaBeneficiaryAddressLine2
+	}
+	if params.SepaBeneficiaryStateProvinceRegion != nil {
+		body["sepa_beneficiary_state_province_region"] = *params.SepaBeneficiaryStateProvinceRegion
+	}
+
+	return request.Do[*CreateSepaResponse](c.cfg, ctx, "POST", path, body)
 }

--- a/bankaccounts/client.go
+++ b/bankaccounts/client.go
@@ -108,19 +108,19 @@ type OfframpWalletInfo struct {
 
 // GetResponse represents a detailed bank account response.
 type GetResponse struct {
-	ID                string                `json:"id"`
-	CustomerID        string                `json:"customer_id"`
-	AccountHolderName string                `json:"account_holder_name"`
-	AccountNumber     string                `json:"account_number"`
-	RoutingNumber     string                `json:"routing_number"`
-	AccountType       types.BankAccountType `json:"account_type"`
-	BankName          string                `json:"bank_name"`
-	SwiftCode         *string               `json:"swift_code"`
-	IBAN              *string               `json:"iban"`
-	IsPrimary         bool                  `json:"is_primary"`
+	ID                 string                `json:"id"`
+	CustomerID         string                `json:"customer_id"`
+	AccountHolderName  string                `json:"account_holder_name"`
+	AccountNumber      string                `json:"account_number"`
+	RoutingNumber      string                `json:"routing_number"`
+	AccountType        types.BankAccountType `json:"account_type"`
+	BankName           string                `json:"bank_name"`
+	SwiftCode          *string               `json:"swift_code"`
+	IBAN               *string               `json:"iban"`
+	IsPrimary          bool                  `json:"is_primary"`
 	SepaBeneficiaryBic *string               `json:"sepa_beneficiary_bic,omitempty"`
-	CreatedAt         time.Time             `json:"created_at"`
-	UpdatedAt         time.Time             `json:"updated_at"`
+	CreatedAt          time.Time             `json:"created_at"`
+	UpdatedAt          time.Time             `json:"updated_at"`
 }
 
 // CreatePixParams represents parameters for creating a PIX bank account.
@@ -931,18 +931,18 @@ func (c *Client) CreateTed(ctx context.Context, params *CreateTedParams) (*Creat
 
 // CreateSepaParams represents parameters for creating a SEPA bank account.
 type CreateSepaParams struct {
-	CustomerID                        string                `json:"-"`
-	Name                              string                `json:"name"`
-	AccountClass                      types.AccountClass    `json:"account_class"`
-	SepaIban                          string                `json:"sepa_iban"`
-	SepaBeneficiaryBic                string                `json:"sepa_beneficiary_bic"`
-	SepaBeneficiaryLegalName          string                `json:"sepa_beneficiary_legal_name"`
-	SepaBeneficiaryAddressLine1       string                `json:"sepa_beneficiary_address_line_1"`
-	SepaBeneficiaryAddressLine2       *string               `json:"sepa_beneficiary_address_line_2,omitempty"`
-	SepaBeneficiaryCity               string                `json:"sepa_beneficiary_city"`
-	SepaBeneficiaryStateProvinceRegion *string              `json:"sepa_beneficiary_state_province_region,omitempty"`
-	SepaBeneficiaryPostalCode         string                `json:"sepa_beneficiary_postal_code"`
-	SepaBeneficiaryCountry            types.Country         `json:"sepa_beneficiary_country"`
+	CustomerID                         string             `json:"-"`
+	Name                               string             `json:"name"`
+	AccountClass                       types.AccountClass `json:"account_class"`
+	SepaIban                           string             `json:"sepa_iban"`
+	SepaBeneficiaryBic                 string             `json:"sepa_beneficiary_bic"`
+	SepaBeneficiaryLegalName           string             `json:"sepa_beneficiary_legal_name"`
+	SepaBeneficiaryAddressLine1        string             `json:"sepa_beneficiary_address_line_1"`
+	SepaBeneficiaryAddressLine2        *string            `json:"sepa_beneficiary_address_line_2,omitempty"`
+	SepaBeneficiaryCity                string             `json:"sepa_beneficiary_city"`
+	SepaBeneficiaryStateProvinceRegion *string            `json:"sepa_beneficiary_state_province_region,omitempty"`
+	SepaBeneficiaryPostalCode          string             `json:"sepa_beneficiary_postal_code"`
+	SepaBeneficiaryCountry             types.Country      `json:"sepa_beneficiary_country"`
 }
 
 // CreateSepaResponse represents the response when creating a SEPA bank account.

--- a/bankaccounts/client.go
+++ b/bankaccounts/client.go
@@ -108,7 +108,7 @@ type OfframpWalletInfo struct {
 // GetResponse represents a detailed bank account response.
 type GetResponse struct {
 	ID                string                `json:"id"`
-	ReceiverID        string                `json:"receiver_id"`
+	CustomerID        string                `json:"customer_id"`
 	AccountHolderName string                `json:"account_holder_name"`
 	AccountNumber     string                `json:"account_number"`
 	RoutingNumber     string                `json:"routing_number"`
@@ -123,7 +123,7 @@ type GetResponse struct {
 
 // CreatePixParams represents parameters for creating a PIX bank account.
 type CreatePixParams struct {
-	ReceiverID string `json:"-"`
+	CustomerID string `json:"-"`
 	Name       string `json:"name"`
 	PixKey     string `json:"pix_key"`
 }
@@ -281,7 +281,7 @@ type CreateRtpResponse struct {
 
 // CreateTedParams represents parameters for creating a TED bank account.
 type CreateTedParams struct {
-	ReceiverID            string                      `json:"-"`
+	CustomerID            string                      `json:"-"`
 	Name                  string                      `json:"name"`
 	BeneficiaryName       string                      `json:"beneficiary_name"`
 	TedBankCode           string                      `json:"ted_bank_code"`
@@ -323,7 +323,7 @@ type CreateTedResponse struct {
 
 // CreatePixSafeParams represents parameters for creating a PIX Safe bank account.
 type CreatePixSafeParams struct {
-	ReceiverID        string                `json:"-"`
+	CustomerID        string                `json:"-"`
 	Name              string                `json:"name"`
 	BeneficiaryName   string                `json:"beneficiary_name"`
 	AccountNumber     string                `json:"account_number"`
@@ -349,7 +349,7 @@ type CreatePixSafeResponse struct {
 
 // ListParams represents parameters for listing bank accounts with optional filters.
 type ListParams struct {
-	ReceiverID    string     `json:"-"`
+	CustomerID    string     `json:"-"`
 	Status        string     `json:"status,omitempty"`
 	Type          types.Rail `json:"type,omitempty"`
 	Name          string     `json:"name,omitempty"`
@@ -359,7 +359,7 @@ type ListParams struct {
 
 // CreateAchParams represents parameters for creating an ACH bank account.
 type CreateAchParams struct {
-	ReceiverID            string                      `json:"-"`
+	CustomerID            string                      `json:"-"`
 	Name                  string                      `json:"name"`
 	AccountClass          types.AccountClass          `json:"account_class"`
 	AccountNumber         string                      `json:"account_number"`
@@ -381,7 +381,7 @@ type CreateAchParams struct {
 
 // CreateWireParams represents parameters for creating a Wire bank account.
 type CreateWireParams struct {
-	ReceiverID            string                      `json:"-"`
+	CustomerID            string                      `json:"-"`
 	Name                  string                      `json:"name"`
 	AccountClass          types.AccountClass          `json:"account_class"`
 	AccountNumber         string                      `json:"account_number"`
@@ -402,7 +402,7 @@ type CreateWireParams struct {
 
 // CreateArgentinaTransfersParams represents parameters for creating an Argentina transfers bank account.
 type CreateArgentinaTransfersParams struct {
-	ReceiverID       string             `json:"-"`
+	CustomerID       string             `json:"-"`
 	Name             string             `json:"name"`
 	BeneficiaryName  string             `json:"beneficiary_name"`
 	TransfersAccount string             `json:"transfers_account"`
@@ -411,7 +411,7 @@ type CreateArgentinaTransfersParams struct {
 
 // CreateSpeiParams represents parameters for creating a SPEI bank account.
 type CreateSpeiParams struct {
-	ReceiverID          string       `json:"-"`
+	CustomerID          string       `json:"-"`
 	BeneficiaryName     string       `json:"beneficiary_name"`
 	Name                string       `json:"name"`
 	SpeiClabe           string       `json:"spei_clabe"`
@@ -421,7 +421,7 @@ type CreateSpeiParams struct {
 
 // CreateColombiaAchParams represents parameters for creating a Colombia ACH bank account.
 type CreateColombiaAchParams struct {
-	ReceiverID                 string                `json:"-"`
+	CustomerID                 string                `json:"-"`
 	Name                       string                `json:"name"`
 	AccountType                types.BankAccountType `json:"account_type"`
 	AchCopBeneficiaryFirstName string                `json:"ach_cop_beneficiary_first_name"`
@@ -435,7 +435,7 @@ type CreateColombiaAchParams struct {
 
 // CreateInternationalSwiftParams represents parameters for creating an international SWIFT bank account.
 type CreateInternationalSwiftParams struct {
-	ReceiverID                             string                      `json:"-"`
+	CustomerID                             string                      `json:"-"`
 	Name                                   string                      `json:"name"`
 	AccountClass                           types.AccountClass          `json:"account_class"`
 	RecipientRelationship                  types.RecipientRelationship `json:"recipient_relationship"`
@@ -468,7 +468,7 @@ type CreateInternationalSwiftParams struct {
 
 // CreateRtpParams represents parameters for creating an RTP (Real-Time Payments) bank account.
 type CreateRtpParams struct {
-	ReceiverID            string                      `json:"-"`
+	CustomerID            string                      `json:"-"`
 	Name                  string                      `json:"name"`
 	AccountClass          types.AccountClass          `json:"account_class"`
 	BeneficiaryName       string                      `json:"beneficiary_name"`
@@ -501,16 +501,16 @@ func NewClient(cfg *config.Config) *Client {
 	}
 }
 
-// List retrieves all bank accounts for a receiver with optional filters.
+// List retrieves all bank accounts for a customer with optional filters.
 func (c *Client) List(ctx context.Context, params *ListParams) ([]BankAccount, error) {
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	q := url.Values{}
 	if params.Status != "" {
@@ -536,28 +536,28 @@ func (c *Client) List(ctx context.Context, params *ListParams) ([]BankAccount, e
 }
 
 // Get retrieves a specific bank account.
-func (c *Client) Get(ctx context.Context, receiverID, id string) (*GetResponse, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Get(ctx context.Context, customerID, id string) (*GetResponse, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return nil, fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s", c.instanceID, customerID, id)
 	return request.Do[*GetResponse](c.cfg, ctx, "GET", path, nil)
 }
 
 // Delete deletes a bank account.
-func (c *Client) Delete(ctx context.Context, receiverID, id string) error {
-	if receiverID == "" {
-		return fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Delete(ctx context.Context, customerID, id string) error {
+	if customerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s", c.instanceID, customerID, id)
 	_, err := request.Do[struct{}](c.cfg, ctx, "DELETE", path, nil)
 	return err
 }
@@ -567,11 +567,11 @@ func (c *Client) CreatePix(ctx context.Context, params *CreatePixParams) (*Creat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":    "pix",
@@ -587,11 +587,11 @@ func (c *Client) CreateAch(ctx context.Context, params *CreateAchParams) (*Creat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                   "ach",
@@ -633,11 +633,11 @@ func (c *Client) CreateWire(ctx context.Context, params *CreateWireParams) (*Cre
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                   "wire",
@@ -678,11 +678,11 @@ func (c *Client) CreateArgentinaTransfers(ctx context.Context, params *CreateArg
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":              "transfers_bitso",
@@ -700,11 +700,11 @@ func (c *Client) CreateSpei(ctx context.Context, params *CreateSpeiParams) (*Cre
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                  "spei_bitso",
@@ -723,11 +723,11 @@ func (c *Client) CreateColombiaAch(ctx context.Context, params *CreateColombiaAc
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                           "ach_cop_bitso",
@@ -750,11 +750,11 @@ func (c *Client) CreateInternationalSwift(ctx context.Context, params *CreateInt
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                                        "international_swift",
@@ -811,11 +811,11 @@ func (c *Client) CreatePixSafe(ctx context.Context, params *CreatePixSafeParams)
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                 "pix_safe",
@@ -836,11 +836,11 @@ func (c *Client) CreateRtp(ctx context.Context, params *CreateRtpParams) (*Creat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                   "rtp",
@@ -881,11 +881,11 @@ func (c *Client) CreateTed(ctx context.Context, params *CreateTedParams) (*Creat
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"type":                   "ted",

--- a/blindpay.go
+++ b/blindpay.go
@@ -49,8 +49,8 @@ type Client struct {
 	Quotes           *quotes.Client
 	// Deprecated: use Customers instead. The receivers resource will be removed in a future major version.
 	// See https://www.blindpay.com/changelog/2026-06-04-customers-rename
-	Receivers *receivers.Client
-	Tos       *termsofservice.Client
+	Receivers        *receivers.Client
+	Tos              *termsofservice.Client
 	Transfers        *transfers.Client
 	Upload           *upload.Client
 	VirtualAccounts  *virtualaccounts.Client

--- a/blindpay.go
+++ b/blindpay.go
@@ -9,6 +9,7 @@ import (
 	"github.com/blindpaylabs/blindpay-go/available"
 	"github.com/blindpaylabs/blindpay-go/bankaccounts"
 	"github.com/blindpaylabs/blindpay-go/custodialwallets"
+	"github.com/blindpaylabs/blindpay-go/customers"
 	"github.com/blindpaylabs/blindpay-go/fees"
 	"github.com/blindpaylabs/blindpay-go/instances"
 	"github.com/blindpaylabs/blindpay-go/internal/config"
@@ -39,14 +40,17 @@ type Client struct {
 	APIKeys          *apikeys.Client
 	BankAccounts     *bankaccounts.Client
 	CustodialWallets *custodialwallets.Client
+	Customers        *customers.Client
 	Fees             *fees.Client
 	Instances        *instances.Client
 	PartnerFees      *partnerfees.Client
 	Payins           *payins.Client
 	Payouts          *payouts.Client
 	Quotes           *quotes.Client
-	Receivers        *receivers.Client
-	Tos              *termsofservice.Client
+	// Deprecated: use Customers instead. The receivers resource will be removed in a future major version.
+	// See https://www.blindpay.com/changelog/2026-06-04-customers-rename
+	Receivers *receivers.Client
+	Tos       *termsofservice.Client
 	Transfers        *transfers.Client
 	Upload           *upload.Client
 	VirtualAccounts  *virtualaccounts.Client
@@ -90,6 +94,7 @@ func New(apiKey, instanceID string, opts ...Option) (*Client, error) {
 	c.APIKeys = apikeys.NewClient(cfg)
 	c.BankAccounts = bankaccounts.NewClient(cfg)
 	c.CustodialWallets = custodialwallets.NewClient(cfg)
+	c.Customers = customers.NewClient(cfg)
 	c.Fees = fees.NewClient(cfg)
 	c.Instances = instances.NewClient(cfg)
 	c.PartnerFees = partnerfees.NewClient(cfg)

--- a/blindpay.go
+++ b/blindpay.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Version is the current version of the SDK.
-const Version = "1.13.0"
+const Version = "1.14.0"
 
 // Client is the main BlindPay client.
 type Client struct {

--- a/custodialwallets/client.go
+++ b/custodialwallets/client.go
@@ -22,7 +22,7 @@ type CustodialWallet struct {
 
 // CreateParams represents parameters for creating a custodial wallet.
 type CreateParams struct {
-	ReceiverID string        `json:"-"`
+	CustomerID string        `json:"-"`
 	Name       string        `json:"name"`
 	Network    types.Network `json:"network"`
 	ExternalID *string       `json:"external_id,omitempty"`
@@ -57,26 +57,26 @@ func NewClient(cfg *config.Config) *Client {
 	}
 }
 
-// List retrieves all custodial wallets for a receiver.
-func (c *Client) List(ctx context.Context, receiverID string) ([]CustodialWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+// List retrieves all custodial wallets for a customer.
+func (c *Client) List(ctx context.Context, customerID string) ([]CustodialWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/wallets", c.instanceID, receiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/wallets", c.instanceID, customerID)
 	return request.Do[[]CustodialWallet](c.cfg, ctx, "GET", path, nil)
 }
 
 // Get retrieves a specific custodial wallet.
-func (c *Client) Get(ctx context.Context, receiverID, id string) (*CustodialWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Get(ctx context.Context, customerID, id string) (*CustodialWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return nil, fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/wallets/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/wallets/%s", c.instanceID, customerID, id)
 	return request.Do[*CustodialWallet](c.cfg, ctx, "GET", path, nil)
 }
 
@@ -85,11 +85,11 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*CustodialWa
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/wallets", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/wallets", c.instanceID, params.CustomerID)
 
 	body := map[string]any{
 		"name":    params.Name,
@@ -104,28 +104,28 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*CustodialWa
 }
 
 // GetBalance retrieves the balance of a custodial wallet.
-func (c *Client) GetBalance(ctx context.Context, receiverID, id string) (*GetBalanceResponse, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) GetBalance(ctx context.Context, customerID, id string) (*GetBalanceResponse, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return nil, fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/wallets/%s/balance", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/wallets/%s/balance", c.instanceID, customerID, id)
 	return request.Do[*GetBalanceResponse](c.cfg, ctx, "GET", path, nil)
 }
 
 // Delete deletes a custodial wallet.
-func (c *Client) Delete(ctx context.Context, receiverID, id string) error {
-	if receiverID == "" {
-		return fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Delete(ctx context.Context, customerID, id string) error {
+	if customerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/wallets/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/wallets/%s", c.instanceID, customerID, id)
 	_, err := request.Do[struct{}](c.cfg, ctx, "DELETE", path, nil)
 	return err
 }

--- a/custodialwallets/custodialwallets_test.go
+++ b/custodialwallets/custodialwallets_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCustodialWallets_List(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -33,14 +33,14 @@ func TestCustodialWallets_List(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}]`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/wallets", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/wallets", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	wallets, err := client.List(context.Background(), receiverID)
+	wallets, err := client.List(context.Background(), customerID)
 	require.NoError(t, err)
 	require.Len(t, wallets, 1)
 	require.Equal(t, "cw_000000000000", wallets[0].ID)
@@ -48,7 +48,7 @@ func TestCustodialWallets_List(t *testing.T) {
 
 func TestCustodialWallets_Create(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 
 	cfg := &config.Config{
 		BaseURL:    "https://api.blindpay.com",
@@ -66,7 +66,7 @@ func TestCustodialWallets_Create(t *testing.T) {
 					"created_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/wallets", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/wallets", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -74,7 +74,7 @@ func TestCustodialWallets_Create(t *testing.T) {
 
 	client := NewClient(cfg)
 	wallet, err := client.Create(context.Background(), &CreateParams{
-		ReceiverID: receiverID,
+		CustomerID: customerID,
 		Name:       "My Wallet",
 		Network:    types.NetworkBase,
 	})
@@ -85,7 +85,7 @@ func TestCustodialWallets_Create(t *testing.T) {
 
 func TestCustodialWallets_GetBalance(t *testing.T) {
 	instanceID := "in_000000000000"
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	walletID := "cw_000000000000"
 
 	cfg := &config.Config{
@@ -101,14 +101,14 @@ func TestCustodialWallets_GetBalance(t *testing.T) {
 					"USDB":{"address":"0x789","id":"tok_3","symbol":"USDB","amount":0}
 				}`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/wallets/%s/balance", instanceID, receiverID, walletID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/wallets/%s/balance", instanceID, customerID, walletID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	balance, err := client.GetBalance(context.Background(), receiverID, walletID)
+	balance, err := client.GetBalance(context.Background(), customerID, walletID)
 	require.NoError(t, err)
 	require.Equal(t, 100.5, balance.USDC.Amount)
 	require.Equal(t, 50.25, balance.USDT.Amount)

--- a/customers/client.go
+++ b/customers/client.go
@@ -1,0 +1,1029 @@
+package customers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/blindpaylabs/blindpay-go/internal/config"
+	"github.com/blindpaylabs/blindpay-go/internal/request"
+	"github.com/blindpaylabs/blindpay-go/internal/types"
+)
+
+// ProofOfAddressDocType represents proof of address document types.
+type ProofOfAddressDocType string
+
+const (
+	ProofOfAddressDocTypeUtilityBill              ProofOfAddressDocType = "UTILITY_BILL"
+	ProofOfAddressDocTypeBankStatement            ProofOfAddressDocType = "BANK_STATEMENT"
+	ProofOfAddressDocTypeRentalAgreement          ProofOfAddressDocType = "RENTAL_AGREEMENT"
+	ProofOfAddressDocTypeTaxDocument              ProofOfAddressDocType = "TAX_DOCUMENT"
+	ProofOfAddressDocTypeGovernmentCorrespondence ProofOfAddressDocType = "GOVERNMENT_CORRESPONDENCE"
+)
+
+// PurposeOfTransactions represents the purpose of transactions.
+type PurposeOfTransactions string
+
+const (
+	PurposeBusinessTransactions            PurposeOfTransactions = "business_transactions"
+	PurposeCharitableDonations             PurposeOfTransactions = "charitable_donations"
+	PurposeInvestmentPurposes              PurposeOfTransactions = "investment_purposes"
+	PurposePaymentsToFriendsOrFamilyAbroad PurposeOfTransactions = "payments_to_friends_or_family_abroad"
+	PurposePersonalOrLivingExpenses        PurposeOfTransactions = "personal_or_living_expenses"
+	PurposeProtectWealth                   PurposeOfTransactions = "protect_wealth"
+	PurposePurchaseGoodAndServices         PurposeOfTransactions = "purchase_good_and_services"
+	PurposeReceivePaymentForFreelancing    PurposeOfTransactions = "receive_payment_for_freelancing"
+	PurposeReceiveSalary                   PurposeOfTransactions = "receive_salary"
+	PurposeOther                           PurposeOfTransactions = "other"
+)
+
+// SourceOfFundsDocType represents source of funds document types.
+type SourceOfFundsDocType string
+
+const (
+	SourceOfFundsBusinessIncome         SourceOfFundsDocType = "business_income"
+	SourceOfFundsGamblingProceeds       SourceOfFundsDocType = "gambling_proceeds"
+	SourceOfFundsGifts                  SourceOfFundsDocType = "gifts"
+	SourceOfFundsGovernmentBenefits     SourceOfFundsDocType = "government_benefits"
+	SourceOfFundsInheritance            SourceOfFundsDocType = "inheritance"
+	SourceOfFundsInvestmentLoans        SourceOfFundsDocType = "investment_loans"
+	SourceOfFundsPensionRetirement      SourceOfFundsDocType = "pension_retirement"
+	SourceOfFundsSalary                 SourceOfFundsDocType = "salary"
+	SourceOfFundsSaleOfAssetsRealEstate SourceOfFundsDocType = "sale_of_assets_real_estate"
+	SourceOfFundsSavings                SourceOfFundsDocType = "savings"
+	SourceOfFundsESOPs                  SourceOfFundsDocType = "esops"
+	SourceOfFundsInvestmentProceeds     SourceOfFundsDocType = "investment_proceeds"
+	SourceOfFundsSomeoneElseFunds       SourceOfFundsDocType = "someone_else_funds"
+)
+
+// LimitIncreaseRequestStatus represents the status of a limit increase request.
+type LimitIncreaseRequestStatus string
+
+const (
+	LimitIncreaseRequestStatusInReview LimitIncreaseRequestStatus = "in_review"
+	LimitIncreaseRequestStatusApproved LimitIncreaseRequestStatus = "approved"
+	LimitIncreaseRequestStatusRejected LimitIncreaseRequestStatus = "rejected"
+)
+
+// LimitIncreaseRequestSupportingDocumentType represents supporting document types for limit increase requests.
+type LimitIncreaseRequestSupportingDocumentType string
+
+const (
+	LimitIncreaseRequestSupportingDocumentTypeIndividualBankStatement     LimitIncreaseRequestSupportingDocumentType = "individual_bank_statement"
+	LimitIncreaseRequestSupportingDocumentTypeIndividualTaxReturn         LimitIncreaseRequestSupportingDocumentType = "individual_tax_return"
+	LimitIncreaseRequestSupportingDocumentTypeIndividualProofOfIncome     LimitIncreaseRequestSupportingDocumentType = "individual_proof_of_income"
+	LimitIncreaseRequestSupportingDocumentTypeBusinessBankStatement       LimitIncreaseRequestSupportingDocumentType = "business_bank_statement"
+	LimitIncreaseRequestSupportingDocumentTypeBusinessFinancialStatements LimitIncreaseRequestSupportingDocumentType = "business_financial_statements"
+	LimitIncreaseRequestSupportingDocumentTypeBusinessTaxReturn           LimitIncreaseRequestSupportingDocumentType = "business_tax_return"
+)
+
+// IdentificationDocument represents identification document types.
+type IdentificationDocument string
+
+const (
+	IdentificationDocumentPassport IdentificationDocument = "PASSPORT"
+	IdentificationDocumentIDCard   IdentificationDocument = "ID_CARD"
+	IdentificationDocumentDrivers  IdentificationDocument = "DRIVERS"
+)
+
+// KycType represents KYC verification levels.
+type KycType string
+
+const (
+	KycTypeLight    KycType = "light"
+	KycTypeStandard KycType = "standard"
+	KycTypeEnhanced KycType = "enhanced"
+)
+
+// OwnerRole represents the role of an owner in a business.
+type OwnerRole string
+
+const (
+	OwnerRoleBeneficialControlling OwnerRole = "beneficial_controlling"
+	OwnerRoleBeneficialOwner       OwnerRole = "beneficial_owner"
+	OwnerRoleControllingPerson     OwnerRole = "controlling_person"
+)
+
+// KycStatus represents KYC verification status.
+type KycStatus string
+
+const (
+	KycStatusVerifying         KycStatus = "verifying"
+	KycStatusApproved          KycStatus = "approved"
+	KycStatusRejected          KycStatus = "rejected"
+	KycStatusDeprecated        KycStatus = "deprecated"
+	KycStatusPendingReview     KycStatus = "pending_review"
+	KycStatusAwaitingContract  KycStatus = "awaiting_contract"
+	KycStatusComplianceRequest KycStatus = "compliance_request"
+)
+
+// AccountPurpose represents the purpose of the account.
+type AccountPurpose string
+
+const (
+	AccountPurposeCharitableDonations                AccountPurpose = "charitable_donations"
+	AccountPurposeEcommerceRetailPayments            AccountPurpose = "ecommerce_retail_payments"
+	AccountPurposeInvestmentPurposes                 AccountPurpose = "investment_purposes"
+	AccountPurposeBusinessExpenses                   AccountPurpose = "business_expenses"
+	AccountPurposePaymentsToFriendsOrFamilyAbroad    AccountPurpose = "payments_to_friends_or_family_abroad"
+	AccountPurposePersonalOrLivingExpenses           AccountPurpose = "personal_or_living_expenses"
+	AccountPurposeProtectWealth                      AccountPurpose = "protect_wealth"
+	AccountPurposePurchaseGoodsAndServices           AccountPurpose = "purchase_goods_and_services"
+	AccountPurposeReceivePaymentsForGoodsAndServices AccountPurpose = "receive_payments_for_goods_and_services"
+	AccountPurposeTaxOptimization                    AccountPurpose = "tax_optimization"
+	AccountPurposeThirdPartyMoneyTransmission        AccountPurpose = "third_party_money_transmission"
+	AccountPurposePayroll                            AccountPurpose = "payroll"
+	AccountPurposeTreasuryManagement                 AccountPurpose = "treasury_management"
+	AccountPurposeOther                              AccountPurpose = "other"
+)
+
+// BusinessType represents the type of business entity.
+type BusinessType string
+
+const (
+	BusinessTypeCorporation        BusinessType = "corporation"
+	BusinessTypeLLC                BusinessType = "llc"
+	BusinessTypePartnership        BusinessType = "partnership"
+	BusinessTypeSoleProprietorship BusinessType = "sole_proprietorship"
+	BusinessTypeTrust              BusinessType = "trust"
+	BusinessTypeNonProfit          BusinessType = "non_profit"
+)
+
+// EstimatedAnnualRevenue represents estimated annual revenue ranges.
+type EstimatedAnnualRevenue string
+
+const (
+	EstimatedAnnualRevenue0To99999            EstimatedAnnualRevenue = "0_99999"
+	EstimatedAnnualRevenue100000To999999      EstimatedAnnualRevenue = "100000_999999"
+	EstimatedAnnualRevenue1000000To9999999    EstimatedAnnualRevenue = "1000000_9999999"
+	EstimatedAnnualRevenue10000000To49999999  EstimatedAnnualRevenue = "10000000_49999999"
+	EstimatedAnnualRevenue50000000To249999999 EstimatedAnnualRevenue = "50000000_249999999"
+	EstimatedAnnualRevenue2500000000Plus      EstimatedAnnualRevenue = "2500000000_plus"
+)
+
+// SourceOfWealth represents the source of wealth for a customer.
+type SourceOfWealth string
+
+const (
+	SourceOfWealthBusinessDividendsOrProfits  SourceOfWealth = "business_dividends_or_profits"
+	SourceOfWealthInvestments                 SourceOfWealth = "investments"
+	SourceOfWealthAssetSales                  SourceOfWealth = "asset_sales"
+	SourceOfWealthClientInvestorContributions SourceOfWealth = "client_investor_contributions"
+	SourceOfWealthGambling                    SourceOfWealth = "gambling"
+	SourceOfWealthCharitableContributions     SourceOfWealth = "charitable_contributions"
+	SourceOfWealthInheritance                 SourceOfWealth = "inheritance"
+	SourceOfWealthAffiliateOrRoyaltyIncome    SourceOfWealth = "affiliate_or_royalty_income"
+)
+
+// AmlStatus represents AML screening status.
+type AmlStatus string
+
+const (
+	AmlStatusClear AmlStatus = "clear"
+	AmlStatusHit   AmlStatus = "hit"
+	AmlStatusError AmlStatus = "error"
+)
+
+// TaxType represents tax identifier types.
+type TaxType string
+
+const (
+	TaxTypeSSN  TaxType = "SSN"
+	TaxTypeITIN TaxType = "ITIN"
+)
+
+// FraudWarning represents a fraud warning.
+type FraudWarning struct {
+	ID        *string  `json:"id"`
+	Name      *string  `json:"name"`
+	Operation *string  `json:"operation"`
+	Score     *float64 `json:"score"`
+}
+
+// AmlHits represents AML screening match details.
+type AmlHits struct {
+	HasSanctionMatch     bool `json:"has_sanction_match"`
+	HasPepMatch          bool `json:"has_pep_match"`
+	HasWatchlistMatch    bool `json:"has_watchlist_match"`
+	HasCrimelistMatch    bool `json:"has_crimelist_match"`
+	HasAdversemediaMatch bool `json:"has_adversemedia_match"`
+}
+
+// Owner represents a business owner.
+type Owner struct {
+	ID                    string                 `json:"id,omitempty"`
+	InstanceID            string                 `json:"instance_id,omitempty"`
+	CustomerID            string                 `json:"customer_id,omitempty"`
+	Role                  OwnerRole              `json:"role"`
+	FirstName             string                 `json:"first_name"`
+	LastName              string                 `json:"last_name"`
+	DateOfBirth           string                 `json:"date_of_birth"`
+	TaxID                 string                 `json:"tax_id"`
+	AddressLine1          string                 `json:"address_line_1"`
+	AddressLine2          *string                `json:"address_line_2"`
+	City                  string                 `json:"city"`
+	StateProvinceRegion   string                 `json:"state_province_region"`
+	Country               types.Country          `json:"country"`
+	PostalCode            string                 `json:"postal_code"`
+	IDDocCountry          types.Country          `json:"id_doc_country"`
+	IDDocType             IdentificationDocument `json:"id_doc_type"`
+	IDDocFrontFile        string                 `json:"id_doc_front_file"`
+	IDDocBackFile         *string                `json:"id_doc_back_file"`
+	ProofOfAddressDocType ProofOfAddressDocType  `json:"proof_of_address_doc_type"`
+	ProofOfAddressDocFile string                 `json:"proof_of_address_doc_file"`
+	OwnershipPercentage   *int                   `json:"ownership_percentage,omitempty"`
+	Title                 *string                `json:"title,omitempty"`
+	TaxType               TaxType                `json:"tax_type,omitempty"`
+}
+
+// KycWarning represents a KYC warning.
+type KycWarning struct {
+	Code             *string `json:"code"`
+	Message          *string `json:"message"`
+	ResolutionStatus *string `json:"resolution_status"`
+	WarningID        *string `json:"warning_id"`
+}
+
+// Limits represents transaction limits.
+type Limits struct {
+	PerTransaction float64 `json:"per_transaction"`
+	Daily          float64 `json:"daily"`
+	Monthly        float64 `json:"monthly"`
+}
+
+// Customer represents a customer with KYC information.
+type Customer struct {
+	ID                    string                `json:"id"`
+	Type                  types.AccountClass    `json:"type"`
+	KycType               KycType               `json:"kyc_type"`
+	KycStatus             string                `json:"kyc_status"`
+	KycWarnings           []KycWarning          `json:"kyc_warnings"`
+	Email                 string                `json:"email"`
+	TaxID                 string                `json:"tax_id"`
+	AddressLine1          string                `json:"address_line_1"`
+	AddressLine2          *string               `json:"address_line_2"`
+	City                  string                `json:"city"`
+	StateProvinceRegion   string                `json:"state_province_region"`
+	Country               types.Country         `json:"country"`
+	PostalCode            string                `json:"postal_code"`
+	IPAddress             *string               `json:"ip_address"`
+	ImageURL              *string               `json:"image_url"`
+	PhoneNumber           *string               `json:"phone_number"`
+	ProofOfAddressDocType ProofOfAddressDocType `json:"proof_of_address_doc_type"`
+	ProofOfAddressDocFile string                `json:"proof_of_address_doc_file"`
+	AipriseValidationKey  string                `json:"aiprise_validation_key"`
+	InstanceID            string                `json:"instance_id"`
+	TosID                 *string               `json:"tos_id"`
+	CreatedAt             time.Time             `json:"created_at"`
+	UpdatedAt             time.Time             `json:"updated_at"`
+	Limit                 Limits                `json:"limit"`
+	// Individual fields
+	FirstName      string                 `json:"first_name,omitempty"`
+	LastName       string                 `json:"last_name,omitempty"`
+	DateOfBirth    string                 `json:"date_of_birth,omitempty"`
+	IDDocCountry   types.Country          `json:"id_doc_country,omitempty"`
+	IDDocType      IdentificationDocument `json:"id_doc_type,omitempty"`
+	IDDocFrontFile string                 `json:"id_doc_front_file,omitempty"`
+	IDDocBackFile  *string                `json:"id_doc_back_file,omitempty"`
+	// Enhanced KYC fields
+	SourceOfFundsDocType             string                `json:"source_of_funds_doc_type,omitempty"`
+	SourceOfFundsDocFile             string                `json:"source_of_funds_doc_file,omitempty"`
+	SelfieFile                       string                `json:"selfie_file,omitempty"`
+	PurposeOfTransactions            PurposeOfTransactions `json:"purpose_of_transactions,omitempty"`
+	PurposeOfTransactionsExplanation *string               `json:"purpose_of_transactions_explanation,omitempty"`
+	// Business fields
+	LegalName               string                       `json:"legal_name,omitempty"`
+	AlternateName           *string                      `json:"alternate_name,omitempty"`
+	FormationDate           string                       `json:"formation_date,omitempty"`
+	Website                 *string                      `json:"website,omitempty"`
+	Owners                  []Owner                      `json:"owners,omitempty"`
+	IncorporationDocFile    string                       `json:"incorporation_doc_file,omitempty"`
+	ProofOfOwnershipDocFile string                       `json:"proof_of_ownership_doc_file,omitempty"`
+	ExternalID              *string                      `json:"external_id,omitempty"`
+	FraudWarnings           []FraudWarning               `json:"fraud_warnings,omitempty"`
+	IsFbo                   *bool                        `json:"is_fbo,omitempty"`
+	AccountPurpose          AccountPurpose               `json:"account_purpose,omitempty"`
+	AccountPurposeOther     *string                      `json:"account_purpose_other,omitempty"`
+	BusinessType            BusinessType                 `json:"business_type,omitempty"`
+	BusinessDescription     *string                      `json:"business_description,omitempty"`
+	BusinessIndustry        types.BusinessIndustry       `json:"business_industry,omitempty"`
+	EstimatedAnnualRevenue  EstimatedAnnualRevenue       `json:"estimated_annual_revenue,omitempty"`
+	SourceOfWealth          SourceOfWealth               `json:"source_of_wealth,omitempty"`
+	PubliclyTraded          *bool                        `json:"publicly_traded,omitempty"`
+	Occupation              *string                      `json:"occupation,omitempty"`
+	RecipientRelationship   *types.RecipientRelationship `json:"recipient_relationship,omitempty"`
+	SoleProprietorDocType   *types.SoleProprietorDocType `json:"sole_proprietor_doc_type,omitempty"`
+	AmlStatus               AmlStatus                    `json:"aml_status,omitempty"`
+	AmlHitsData             *AmlHits                     `json:"aml_hits,omitempty"`
+	IsTosAccepted           *bool                        `json:"is_tos_accepted,omitempty"`
+}
+
+// CreateIndividualStandardParams represents parameters for creating an individual with standard KYC.
+type CreateIndividualStandardParams struct {
+	ExternalID            *string                      `json:"external_id,omitempty"`
+	AddressLine1          string                       `json:"address_line_1"`
+	AddressLine2          *string                      `json:"address_line_2,omitempty"`
+	City                  string                       `json:"city"`
+	Country               types.Country                `json:"country"`
+	DateOfBirth           string                       `json:"date_of_birth"`
+	Email                 string                       `json:"email"`
+	FirstName             string                       `json:"first_name"`
+	PhoneNumber           *string                      `json:"phone_number"`
+	IDDocCountry          types.Country                `json:"id_doc_country"`
+	IDDocFrontFile        string                       `json:"id_doc_front_file"`
+	IDDocType             IdentificationDocument       `json:"id_doc_type"`
+	IDDocBackFile         *string                      `json:"id_doc_back_file,omitempty"`
+	LastName              string                       `json:"last_name"`
+	PostalCode            string                       `json:"postal_code"`
+	ProofOfAddressDocFile string                       `json:"proof_of_address_doc_file"`
+	ProofOfAddressDocType ProofOfAddressDocType        `json:"proof_of_address_doc_type"`
+	StateProvinceRegion   string                       `json:"state_province_region"`
+	TaxID                 string                       `json:"tax_id"`
+	TosID                 string                       `json:"tos_id"`
+	IPAddress             *string                      `json:"ip_address,omitempty"`
+	ImageURL              *string                      `json:"image_url,omitempty"`
+	Occupation            *string                      `json:"occupation,omitempty"`
+	RecipientRelationship *types.RecipientRelationship `json:"recipient_relationship,omitempty"`
+	SoleProprietorDocType *types.SoleProprietorDocType `json:"sole_proprietor_doc_type,omitempty"`
+}
+
+// CreateIndividualEnhancedParams represents parameters for creating an individual with enhanced KYC.
+type CreateIndividualEnhancedParams struct {
+	ExternalID                       *string                      `json:"external_id,omitempty"`
+	AddressLine1                     string                       `json:"address_line_1"`
+	AddressLine2                     *string                      `json:"address_line_2,omitempty"`
+	City                             string                       `json:"city"`
+	Country                          types.Country                `json:"country"`
+	DateOfBirth                      string                       `json:"date_of_birth"`
+	Email                            string                       `json:"email"`
+	FirstName                        string                       `json:"first_name"`
+	IDDocCountry                     types.Country                `json:"id_doc_country"`
+	IDDocFrontFile                   string                       `json:"id_doc_front_file"`
+	IDDocType                        IdentificationDocument       `json:"id_doc_type"`
+	IDDocBackFile                    *string                      `json:"id_doc_back_file,omitempty"`
+	SelfieFile                       string                       `json:"selfie_file"`
+	LastName                         string                       `json:"last_name"`
+	PostalCode                       string                       `json:"postal_code"`
+	PhoneNumber                      *string                      `json:"phone_number"`
+	ProofOfAddressDocFile            string                       `json:"proof_of_address_doc_file"`
+	ProofOfAddressDocType            ProofOfAddressDocType        `json:"proof_of_address_doc_type"`
+	PurposeOfTransactions            PurposeOfTransactions        `json:"purpose_of_transactions"`
+	SourceOfFundsDocFile             string                       `json:"source_of_funds_doc_file"`
+	SourceOfFundsDocType             SourceOfFundsDocType         `json:"source_of_funds_doc_type"`
+	PurposeOfTransactionsExplanation *string                      `json:"purpose_of_transactions_explanation,omitempty"`
+	StateProvinceRegion              string                       `json:"state_province_region"`
+	TaxID                            string                       `json:"tax_id"`
+	TosID                            string                       `json:"tos_id"`
+	IPAddress                        *string                      `json:"ip_address,omitempty"`
+	ImageURL                         *string                      `json:"image_url,omitempty"`
+	Occupation                       *string                      `json:"occupation,omitempty"`
+	RecipientRelationship            *types.RecipientRelationship `json:"recipient_relationship,omitempty"`
+	SoleProprietorDocType            *types.SoleProprietorDocType `json:"sole_proprietor_doc_type,omitempty"`
+}
+
+// CreateBusinessStandardParams represents parameters for creating a business with standard KYB.
+type CreateBusinessStandardParams struct {
+	ExternalID              *string                      `json:"external_id,omitempty"`
+	AddressLine1            string                       `json:"address_line_1"`
+	AddressLine2            *string                      `json:"address_line_2,omitempty"`
+	AlternateName           string                       `json:"alternate_name"`
+	City                    string                       `json:"city"`
+	Country                 types.Country                `json:"country"`
+	Email                   string                       `json:"email"`
+	FormationDate           string                       `json:"formation_date"`
+	IncorporationDocFile    string                       `json:"incorporation_doc_file"`
+	LegalName               string                       `json:"legal_name"`
+	Owners                  []Owner                      `json:"owners"`
+	PostalCode              string                       `json:"postal_code"`
+	ProofOfAddressDocFile   string                       `json:"proof_of_address_doc_file"`
+	ProofOfAddressDocType   ProofOfAddressDocType        `json:"proof_of_address_doc_type"`
+	ProofOfOwnershipDocFile string                       `json:"proof_of_ownership_doc_file"`
+	StateProvinceRegion     string                       `json:"state_province_region"`
+	TaxID                   string                       `json:"tax_id"`
+	TosID                   string                       `json:"tos_id"`
+	Website                 *string                      `json:"website,omitempty"`
+	PhoneNumber             *string                      `json:"phone_number,omitempty"`
+	IPAddress               *string                      `json:"ip_address,omitempty"`
+	ImageURL                *string                      `json:"image_url,omitempty"`
+	AccountPurpose          *AccountPurpose              `json:"account_purpose,omitempty"`
+	AccountPurposeOther     *string                      `json:"account_purpose_other,omitempty"`
+	BusinessTypeField       *BusinessType                `json:"business_type,omitempty"`
+	BusinessDescription     *string                      `json:"business_description,omitempty"`
+	BusinessIndustry        *types.BusinessIndustry      `json:"business_industry,omitempty"`
+	EstimatedAnnualRevenue  *EstimatedAnnualRevenue      `json:"estimated_annual_revenue,omitempty"`
+	SourceOfWealth          *SourceOfWealth              `json:"source_of_wealth,omitempty"`
+	PubliclyTraded          *bool                        `json:"publicly_traded,omitempty"`
+	RecipientRelationship   *types.RecipientRelationship `json:"recipient_relationship,omitempty"`
+	SoleProprietorDocType   *types.SoleProprietorDocType `json:"sole_proprietor_doc_type,omitempty"`
+}
+
+// CreateResponse represents the response when creating a customer.
+type CreateResponse struct {
+	ID string `json:"id"`
+}
+
+// UpdateParams represents parameters for updating a customer.
+type UpdateParams struct {
+	CustomerID                       string                       `json:"-"`
+	Email                            *string                      `json:"email,omitempty"`
+	TaxID                            *string                      `json:"tax_id,omitempty"`
+	AddressLine1                     *string                      `json:"address_line_1,omitempty"`
+	AddressLine2                     *string                      `json:"address_line_2,omitempty"`
+	City                             *string                      `json:"city,omitempty"`
+	StateProvinceRegion              *string                      `json:"state_province_region,omitempty"`
+	Country                          *types.Country               `json:"country,omitempty"`
+	PostalCode                       *string                      `json:"postal_code,omitempty"`
+	IPAddress                        *string                      `json:"ip_address,omitempty"`
+	ImageURL                         *string                      `json:"image_url,omitempty"`
+	PhoneNumber                      *string                      `json:"phone_number,omitempty"`
+	ProofOfAddressDocType            *ProofOfAddressDocType       `json:"proof_of_address_doc_type,omitempty"`
+	ProofOfAddressDocFile            *string                      `json:"proof_of_address_doc_file,omitempty"`
+	FirstName                        *string                      `json:"first_name,omitempty"`
+	LastName                         *string                      `json:"last_name,omitempty"`
+	DateOfBirth                      *string                      `json:"date_of_birth,omitempty"`
+	IDDocCountry                     *types.Country               `json:"id_doc_country,omitempty"`
+	IDDocType                        *IdentificationDocument      `json:"id_doc_type,omitempty"`
+	IDDocFrontFile                   *string                      `json:"id_doc_front_file,omitempty"`
+	IDDocBackFile                    *string                      `json:"id_doc_back_file,omitempty"`
+	LegalName                        *string                      `json:"legal_name,omitempty"`
+	AlternateName                    *string                      `json:"alternate_name,omitempty"`
+	FormationDate                    *string                      `json:"formation_date,omitempty"`
+	Website                          *string                      `json:"website,omitempty"`
+	Owners                           []Owner                      `json:"owners,omitempty"`
+	IncorporationDocFile             *string                      `json:"incorporation_doc_file,omitempty"`
+	ProofOfOwnershipDocFile          *string                      `json:"proof_of_ownership_doc_file,omitempty"`
+	SourceOfFundsDocType             *SourceOfFundsDocType        `json:"source_of_funds_doc_type,omitempty"`
+	SourceOfFundsDocFile             *string                      `json:"source_of_funds_doc_file,omitempty"`
+	SelfieFile                       *string                      `json:"selfie_file,omitempty"`
+	PurposeOfTransactions            *PurposeOfTransactions       `json:"purpose_of_transactions,omitempty"`
+	PurposeOfTransactionsExplanation *string                      `json:"purpose_of_transactions_explanation,omitempty"`
+	ExternalID                       *string                      `json:"external_id,omitempty"`
+	TosID                            *string                      `json:"tos_id,omitempty"`
+	AccountPurpose                   *AccountPurpose              `json:"account_purpose,omitempty"`
+	AccountPurposeOther              *string                      `json:"account_purpose_other,omitempty"`
+	BusinessTypeField                *BusinessType                `json:"business_type,omitempty"`
+	BusinessDescription              *string                      `json:"business_description,omitempty"`
+	BusinessIndustry                 *types.BusinessIndustry      `json:"business_industry,omitempty"`
+	EstimatedAnnualRevenue           *EstimatedAnnualRevenue      `json:"estimated_annual_revenue,omitempty"`
+	SourceOfWealth                   *SourceOfWealth              `json:"source_of_wealth,omitempty"`
+	PubliclyTraded                   *bool                        `json:"publicly_traded,omitempty"`
+	Occupation                       *string                      `json:"occupation,omitempty"`
+	RecipientRelationship            *types.RecipientRelationship `json:"recipient_relationship,omitempty"`
+	SoleProprietorDocType            *types.SoleProprietorDocType `json:"sole_proprietor_doc_type,omitempty"`
+}
+
+// LimitsResponse represents customer limits.
+type LimitsResponse struct {
+	Limits struct {
+		Payin struct {
+			Daily   float64 `json:"daily"`
+			Monthly float64 `json:"monthly"`
+		} `json:"payin"`
+		Payout struct {
+			Daily   float64 `json:"daily"`
+			Monthly float64 `json:"monthly"`
+		} `json:"payout"`
+	} `json:"limits"`
+}
+
+// LimitIncreaseRequest represents a limit increase request for a customer.
+type LimitIncreaseRequest struct {
+	ID                     string                                     `json:"id"`
+	CustomerID             string                                     `json:"customer_id"`
+	Status                 LimitIncreaseRequestStatus                 `json:"status"`
+	Daily                  float64                                    `json:"daily"`
+	Monthly                float64                                    `json:"monthly"`
+	PerTransaction         float64                                    `json:"per_transaction"`
+	ApprovedPerTransaction *int                                       `json:"approved_per_transaction,omitempty"`
+	ApprovedDaily          *int                                       `json:"approved_daily,omitempty"`
+	ApprovedMonthly        *int                                       `json:"approved_monthly,omitempty"`
+	SupportingDocumentFile string                                     `json:"supporting_document_file"`
+	SupportingDocumentType LimitIncreaseRequestSupportingDocumentType `json:"supporting_document_type"`
+	CreatedAt              string                                     `json:"created_at"`
+	UpdatedAt              string                                     `json:"updated_at"`
+}
+
+// RequestLimitIncreaseParams represents parameters for requesting a limit increase.
+type RequestLimitIncreaseParams struct {
+	CustomerID             string                                     `json:"-"`
+	Daily                  float64                                    `json:"daily"`
+	Monthly                float64                                    `json:"monthly"`
+	PerTransaction         float64                                    `json:"per_transaction"`
+	SupportingDocumentFile string                                     `json:"supporting_document_file"`
+	SupportingDocumentType LimitIncreaseRequestSupportingDocumentType `json:"supporting_document_type"`
+}
+
+// RequestLimitIncreaseResponse represents the response when requesting a limit increase.
+type RequestLimitIncreaseResponse struct {
+	ID string `json:"id"`
+}
+
+// ListParams represents parameters for listing customers with pagination.
+type ListParams struct {
+	Limit         string    `json:"-"`
+	Offset        string    `json:"-"`
+	StartingAfter string    `json:"-"`
+	EndingBefore  string    `json:"-"`
+	FullName      string    `json:"-"`
+	CustomerName  string    `json:"-"`
+	Status        KycStatus `json:"-"`
+	CustomerID    string    `json:"-"`
+	BankAccountID string    `json:"-"`
+	Country       string    `json:"-"`
+}
+
+// ListResponse represents a paginated list of customers.
+type ListResponse struct {
+	Data       []Customer               `json:"data"`
+	Pagination types.PaginationMetadata `json:"pagination"`
+}
+
+// Client handles customer-related operations.
+type Client struct {
+	cfg        *request.Config
+	instanceID string
+}
+
+// NewClient creates a new customers client.
+func NewClient(cfg *config.Config) *Client {
+	return &Client{
+		cfg:        cfg.ToRequestConfig(),
+		instanceID: cfg.InstanceID,
+	}
+}
+
+// List retrieves all customers for the instance.
+func (c *Client) List(ctx context.Context) ([]Customer, error) {
+	path := fmt.Sprintf("/instances/%s/customers", c.instanceID)
+	return request.Do[[]Customer](c.cfg, ctx, "GET", path, nil)
+}
+
+// ListWithParams retrieves customers with pagination and filtering.
+func (c *Client) ListWithParams(ctx context.Context, params *ListParams) (*ListResponse, error) {
+	path := fmt.Sprintf("/instances/%s/customers", c.instanceID)
+
+	if params != nil {
+		q := url.Values{}
+		if params.Limit != "" {
+			q.Set("limit", params.Limit)
+		}
+		if params.Offset != "" {
+			q.Set("offset", params.Offset)
+		}
+		if params.StartingAfter != "" {
+			q.Set("starting_after", params.StartingAfter)
+		}
+		if params.EndingBefore != "" {
+			q.Set("ending_before", params.EndingBefore)
+		}
+		if params.FullName != "" {
+			q.Set("full_name", params.FullName)
+		}
+		if params.CustomerName != "" {
+			q.Set("customer_name", params.CustomerName)
+		}
+		if params.Status != "" {
+			q.Set("status", string(params.Status))
+		}
+		if params.CustomerID != "" {
+			q.Set("customer_id", params.CustomerID)
+		}
+		if params.BankAccountID != "" {
+			q.Set("bank_account_id", params.BankAccountID)
+		}
+		if params.Country != "" {
+			q.Set("country", params.Country)
+		}
+		if len(q) > 0 {
+			path += "?" + q.Encode()
+		}
+	}
+
+	return request.Do[*ListResponse](c.cfg, ctx, "GET", path, nil)
+}
+
+// CreateIndividualWithStandardKYC creates an individual customer with standard KYC.
+func (c *Client) CreateIndividualWithStandardKYC(ctx context.Context, params *CreateIndividualStandardParams) (*CreateResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers", c.instanceID)
+
+	body := map[string]any{
+		"kyc_type":                  "standard",
+		"type":                      "individual",
+		"address_line_1":            params.AddressLine1,
+		"city":                      params.City,
+		"country":                   params.Country,
+		"date_of_birth":             params.DateOfBirth,
+		"email":                     params.Email,
+		"first_name":                params.FirstName,
+		"id_doc_country":            params.IDDocCountry,
+		"id_doc_front_file":         params.IDDocFrontFile,
+		"id_doc_type":               params.IDDocType,
+		"last_name":                 params.LastName,
+		"postal_code":               params.PostalCode,
+		"proof_of_address_doc_file": params.ProofOfAddressDocFile,
+		"proof_of_address_doc_type": params.ProofOfAddressDocType,
+		"state_province_region":     params.StateProvinceRegion,
+		"tax_id":                    params.TaxID,
+		"tos_id":                    params.TosID,
+	}
+
+	if params.AddressLine2 != nil {
+		body["address_line_2"] = params.AddressLine2
+	}
+	if params.PhoneNumber != nil {
+		body["phone_number"] = params.PhoneNumber
+	}
+	if params.IDDocBackFile != nil {
+		body["id_doc_back_file"] = params.IDDocBackFile
+	}
+	if params.ExternalID != nil {
+		body["external_id"] = params.ExternalID
+	}
+	if params.IPAddress != nil {
+		body["ip_address"] = params.IPAddress
+	}
+	if params.ImageURL != nil {
+		body["image_url"] = params.ImageURL
+	}
+	if params.Occupation != nil {
+		body["occupation"] = params.Occupation
+	}
+	if params.RecipientRelationship != nil {
+		body["recipient_relationship"] = params.RecipientRelationship
+	}
+	if params.SoleProprietorDocType != nil {
+		body["sole_proprietor_doc_type"] = params.SoleProprietorDocType
+	}
+
+	return request.Do[*CreateResponse](c.cfg, ctx, "POST", path, body)
+}
+
+// CreateIndividualWithEnhancedKYC creates an individual customer with enhanced KYC.
+func (c *Client) CreateIndividualWithEnhancedKYC(ctx context.Context, params *CreateIndividualEnhancedParams) (*CreateResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers", c.instanceID)
+
+	body := map[string]any{
+		"kyc_type":                  "enhanced",
+		"type":                      "individual",
+		"address_line_1":            params.AddressLine1,
+		"city":                      params.City,
+		"country":                   params.Country,
+		"date_of_birth":             params.DateOfBirth,
+		"email":                     params.Email,
+		"first_name":                params.FirstName,
+		"id_doc_country":            params.IDDocCountry,
+		"id_doc_front_file":         params.IDDocFrontFile,
+		"id_doc_type":               params.IDDocType,
+		"selfie_file":               params.SelfieFile,
+		"last_name":                 params.LastName,
+		"postal_code":               params.PostalCode,
+		"proof_of_address_doc_file": params.ProofOfAddressDocFile,
+		"proof_of_address_doc_type": params.ProofOfAddressDocType,
+		"purpose_of_transactions":   params.PurposeOfTransactions,
+		"source_of_funds_doc_file":  params.SourceOfFundsDocFile,
+		"source_of_funds_doc_type":  params.SourceOfFundsDocType,
+		"state_province_region":     params.StateProvinceRegion,
+		"tax_id":                    params.TaxID,
+		"tos_id":                    params.TosID,
+	}
+
+	if params.AddressLine2 != nil {
+		body["address_line_2"] = params.AddressLine2
+	}
+	if params.PhoneNumber != nil {
+		body["phone_number"] = params.PhoneNumber
+	}
+	if params.IDDocBackFile != nil {
+		body["id_doc_back_file"] = params.IDDocBackFile
+	}
+	if params.PurposeOfTransactionsExplanation != nil {
+		body["purpose_of_transactions_explanation"] = params.PurposeOfTransactionsExplanation
+	}
+	if params.ExternalID != nil {
+		body["external_id"] = params.ExternalID
+	}
+	if params.IPAddress != nil {
+		body["ip_address"] = params.IPAddress
+	}
+	if params.ImageURL != nil {
+		body["image_url"] = params.ImageURL
+	}
+	if params.Occupation != nil {
+		body["occupation"] = params.Occupation
+	}
+	if params.RecipientRelationship != nil {
+		body["recipient_relationship"] = params.RecipientRelationship
+	}
+	if params.SoleProprietorDocType != nil {
+		body["sole_proprietor_doc_type"] = params.SoleProprietorDocType
+	}
+
+	return request.Do[*CreateResponse](c.cfg, ctx, "POST", path, body)
+}
+
+// CreateBusinessWithStandardKYB creates a business customer with standard KYB.
+func (c *Client) CreateBusinessWithStandardKYB(ctx context.Context, params *CreateBusinessStandardParams) (*CreateResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers", c.instanceID)
+
+	body := map[string]any{
+		"kyc_type":                    "standard",
+		"type":                        "business",
+		"address_line_1":              params.AddressLine1,
+		"alternate_name":              params.AlternateName,
+		"city":                        params.City,
+		"country":                     params.Country,
+		"email":                       params.Email,
+		"formation_date":              params.FormationDate,
+		"incorporation_doc_file":      params.IncorporationDocFile,
+		"legal_name":                  params.LegalName,
+		"owners":                      params.Owners,
+		"postal_code":                 params.PostalCode,
+		"proof_of_address_doc_file":   params.ProofOfAddressDocFile,
+		"proof_of_address_doc_type":   params.ProofOfAddressDocType,
+		"proof_of_ownership_doc_file": params.ProofOfOwnershipDocFile,
+		"state_province_region":       params.StateProvinceRegion,
+		"tax_id":                      params.TaxID,
+		"tos_id":                      params.TosID,
+	}
+
+	if params.AddressLine2 != nil {
+		body["address_line_2"] = params.AddressLine2
+	}
+	if params.Website != nil {
+		body["website"] = params.Website
+	}
+	if params.ExternalID != nil {
+		body["external_id"] = params.ExternalID
+	}
+	if params.PhoneNumber != nil {
+		body["phone_number"] = params.PhoneNumber
+	}
+	if params.IPAddress != nil {
+		body["ip_address"] = params.IPAddress
+	}
+	if params.ImageURL != nil {
+		body["image_url"] = params.ImageURL
+	}
+	if params.AccountPurpose != nil {
+		body["account_purpose"] = params.AccountPurpose
+	}
+	if params.AccountPurposeOther != nil {
+		body["account_purpose_other"] = params.AccountPurposeOther
+	}
+	if params.BusinessTypeField != nil {
+		body["business_type"] = params.BusinessTypeField
+	}
+	if params.BusinessDescription != nil {
+		body["business_description"] = params.BusinessDescription
+	}
+	if params.BusinessIndustry != nil {
+		body["business_industry"] = params.BusinessIndustry
+	}
+	if params.EstimatedAnnualRevenue != nil {
+		body["estimated_annual_revenue"] = params.EstimatedAnnualRevenue
+	}
+	if params.SourceOfWealth != nil {
+		body["source_of_wealth"] = params.SourceOfWealth
+	}
+	if params.PubliclyTraded != nil {
+		body["publicly_traded"] = params.PubliclyTraded
+	}
+	if params.RecipientRelationship != nil {
+		body["recipient_relationship"] = params.RecipientRelationship
+	}
+	if params.SoleProprietorDocType != nil {
+		body["sole_proprietor_doc_type"] = params.SoleProprietorDocType
+	}
+
+	return request.Do[*CreateResponse](c.cfg, ctx, "POST", path, body)
+}
+
+// Get retrieves a specific customer by ID.
+func (c *Client) Get(ctx context.Context, customerID string) (*Customer, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s", c.instanceID, customerID)
+	return request.Do[*Customer](c.cfg, ctx, "GET", path, nil)
+}
+
+// Update updates a customer.
+func (c *Client) Update(ctx context.Context, params *UpdateParams) error {
+	if params == nil {
+		return fmt.Errorf("params cannot be nil")
+	}
+	if params.CustomerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s", c.instanceID, params.CustomerID)
+
+	// Build the request body with only non-nil fields
+	body := make(map[string]any)
+
+	if params.Email != nil {
+		body["email"] = params.Email
+	}
+	if params.TaxID != nil {
+		body["tax_id"] = params.TaxID
+	}
+	if params.AddressLine1 != nil {
+		body["address_line_1"] = params.AddressLine1
+	}
+	if params.AddressLine2 != nil {
+		body["address_line_2"] = params.AddressLine2
+	}
+	if params.City != nil {
+		body["city"] = params.City
+	}
+	if params.StateProvinceRegion != nil {
+		body["state_province_region"] = params.StateProvinceRegion
+	}
+	if params.Country != nil {
+		body["country"] = params.Country
+	}
+	if params.PostalCode != nil {
+		body["postal_code"] = params.PostalCode
+	}
+	if params.IPAddress != nil {
+		body["ip_address"] = params.IPAddress
+	}
+	if params.ImageURL != nil {
+		body["image_url"] = params.ImageURL
+	}
+	if params.PhoneNumber != nil {
+		body["phone_number"] = params.PhoneNumber
+	}
+	if params.ProofOfAddressDocType != nil {
+		body["proof_of_address_doc_type"] = params.ProofOfAddressDocType
+	}
+	if params.ProofOfAddressDocFile != nil {
+		body["proof_of_address_doc_file"] = params.ProofOfAddressDocFile
+	}
+	if params.FirstName != nil {
+		body["first_name"] = params.FirstName
+	}
+	if params.LastName != nil {
+		body["last_name"] = params.LastName
+	}
+	if params.DateOfBirth != nil {
+		body["date_of_birth"] = params.DateOfBirth
+	}
+	if params.IDDocCountry != nil {
+		body["id_doc_country"] = params.IDDocCountry
+	}
+	if params.IDDocType != nil {
+		body["id_doc_type"] = params.IDDocType
+	}
+	if params.IDDocFrontFile != nil {
+		body["id_doc_front_file"] = params.IDDocFrontFile
+	}
+	if params.IDDocBackFile != nil {
+		body["id_doc_back_file"] = params.IDDocBackFile
+	}
+	if params.LegalName != nil {
+		body["legal_name"] = params.LegalName
+	}
+	if params.AlternateName != nil {
+		body["alternate_name"] = params.AlternateName
+	}
+	if params.FormationDate != nil {
+		body["formation_date"] = params.FormationDate
+	}
+	if params.Website != nil {
+		body["website"] = params.Website
+	}
+	if params.Owners != nil {
+		body["owners"] = params.Owners
+	}
+	if params.IncorporationDocFile != nil {
+		body["incorporation_doc_file"] = params.IncorporationDocFile
+	}
+	if params.ProofOfOwnershipDocFile != nil {
+		body["proof_of_ownership_doc_file"] = params.ProofOfOwnershipDocFile
+	}
+	if params.SourceOfFundsDocType != nil {
+		body["source_of_funds_doc_type"] = params.SourceOfFundsDocType
+	}
+	if params.SourceOfFundsDocFile != nil {
+		body["source_of_funds_doc_file"] = params.SourceOfFundsDocFile
+	}
+	if params.SelfieFile != nil {
+		body["selfie_file"] = params.SelfieFile
+	}
+	if params.PurposeOfTransactions != nil {
+		body["purpose_of_transactions"] = params.PurposeOfTransactions
+	}
+	if params.PurposeOfTransactionsExplanation != nil {
+		body["purpose_of_transactions_explanation"] = params.PurposeOfTransactionsExplanation
+	}
+	if params.ExternalID != nil {
+		body["external_id"] = params.ExternalID
+	}
+	if params.TosID != nil {
+		body["tos_id"] = params.TosID
+	}
+	if params.AccountPurpose != nil {
+		body["account_purpose"] = params.AccountPurpose
+	}
+	if params.AccountPurposeOther != nil {
+		body["account_purpose_other"] = params.AccountPurposeOther
+	}
+	if params.BusinessTypeField != nil {
+		body["business_type"] = params.BusinessTypeField
+	}
+	if params.BusinessDescription != nil {
+		body["business_description"] = params.BusinessDescription
+	}
+	if params.BusinessIndustry != nil {
+		body["business_industry"] = params.BusinessIndustry
+	}
+	if params.EstimatedAnnualRevenue != nil {
+		body["estimated_annual_revenue"] = params.EstimatedAnnualRevenue
+	}
+	if params.SourceOfWealth != nil {
+		body["source_of_wealth"] = params.SourceOfWealth
+	}
+	if params.PubliclyTraded != nil {
+		body["publicly_traded"] = params.PubliclyTraded
+	}
+	if params.Occupation != nil {
+		body["occupation"] = params.Occupation
+	}
+	if params.RecipientRelationship != nil {
+		body["recipient_relationship"] = params.RecipientRelationship
+	}
+	if params.SoleProprietorDocType != nil {
+		body["sole_proprietor_doc_type"] = params.SoleProprietorDocType
+	}
+
+	_, err := request.Do[struct{}](c.cfg, ctx, "PUT", path, body)
+	return err
+}
+
+// Delete deletes a customer.
+func (c *Client) Delete(ctx context.Context, customerID string) error {
+	if customerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s", c.instanceID, customerID)
+	_, err := request.Do[struct{}](c.cfg, ctx, "DELETE", path, nil)
+	return err
+}
+
+// GetLimits retrieves transaction limits for a customer.
+func (c *Client) GetLimits(ctx context.Context, customerID string) (*LimitsResponse, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/limits/customers/%s", c.instanceID, customerID)
+	return request.Do[*LimitsResponse](c.cfg, ctx, "GET", path, nil)
+}
+
+// GetLimitIncreaseRequests retrieves all limit increase requests for a customer.
+func (c *Client) GetLimitIncreaseRequests(ctx context.Context, customerID string) ([]LimitIncreaseRequest, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s/limit-increase", c.instanceID, customerID)
+	return request.Do[[]LimitIncreaseRequest](c.cfg, ctx, "GET", path, nil)
+}
+
+// RequestLimitIncrease creates a new limit increase request for a customer.
+func (c *Client) RequestLimitIncrease(ctx context.Context, params *RequestLimitIncreaseParams) (*RequestLimitIncreaseResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/customers/%s/limit-increase", c.instanceID, params.CustomerID)
+
+	body := map[string]any{
+		"daily":                    params.Daily,
+		"monthly":                  params.Monthly,
+		"per_transaction":          params.PerTransaction,
+		"supporting_document_file": params.SupportingDocumentFile,
+		"supporting_document_type": params.SupportingDocumentType,
+	}
+
+	return request.Do[*RequestLimitIncreaseResponse](c.cfg, ctx, "POST", path, body)
+}

--- a/customers/customers_test.go
+++ b/customers/customers_test.go
@@ -1,0 +1,683 @@
+package customers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/blindpaylabs/blindpay-go/internal/blindpaytest"
+	"github.com/blindpaylabs/blindpay-go/internal/config"
+	"github.com/blindpaylabs/blindpay-go/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomers_List(t *testing.T) {
+	instanceID := "in_000000000000"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(`[
+					{
+						"id":"re_Euw7HN4OdxPn",
+						"type":"individual",
+						"kyc_type":"standard",
+						"kyc_status":"verifying",
+						"kyc_warnings":[
+							{
+								"code":null,
+								"message":null,
+								"resolution_status":null,
+								"warning_id":null
+							}
+						],
+						"email":"bernardo@gmail.com",
+						"tax_id":"12345678900",
+						"address_line_1":"Av. Paulista, 1000",
+						"address_line_2":"Apto 101",
+						"city":"São Paulo",
+						"state_province_region":"SP",
+						"country":"BR",
+						"postal_code":"01310-100",
+						"ip_address":"127.0.0.1",
+						"image_url":"https://example.com/image.png",
+						"phone_number":"+5511987654321",
+						"proof_of_address_doc_type":"UTILITY_BILL",
+						"proof_of_address_doc_file":"https://example.com/image.png",
+						"first_name":"Bernardo",
+						"last_name":"Simonassi",
+						"date_of_birth":"1998-02-02T00:00:00.000Z",
+						"id_doc_country":"BR",
+						"id_doc_type":"PASSPORT",
+						"id_doc_front_file":"https://example.com/image.png",
+						"id_doc_back_file":"https://example.com/image.png",
+						"aiprise_validation_key":"",
+						"instance_id":"in_000000000000",
+						"tos_id":"to_3ZZhllJkvo5Z",
+						"created_at":"2021-01-01T00:00:00.000Z",
+						"updated_at":"2021-01-01T00:00:00.000Z",
+						"limit":{
+							"per_transaction":100000,
+							"daily":200000,
+							"monthly":1000000
+						}
+					},
+					{
+						"id":"re_YuaMcI2B8zbQ",
+						"type":"individual",
+						"kyc_type":"enhanced",
+						"kyc_status":"approved",
+						"kyc_warnings":null,
+						"email":"alice.johnson@example.com",
+						"tax_id":"98765432100",
+						"address_line_1":"123 Main St",
+						"address_line_2":null,
+						"city":"New York",
+						"state_province_region":"NY",
+						"country":"US",
+						"postal_code":"10001",
+						"ip_address":"192.168.1.1",
+						"image_url":null,
+						"phone_number":"+15555555555",
+						"proof_of_address_doc_type":"BANK_STATEMENT",
+						"proof_of_address_doc_file":"https://example.com/image.png",
+						"first_name":"Alice",
+						"last_name":"Johnson",
+						"date_of_birth":"1990-05-10T00:00:00.000Z",
+						"id_doc_country":"US",
+						"id_doc_type":"PASSPORT",
+						"id_doc_front_file":"https://example.com/image.png",
+						"id_doc_back_file":null,
+						"aiprise_validation_key":"enhanced-key",
+						"instance_id":"in_000000000001",
+						"source_of_funds_doc_type":"salary",
+						"source_of_funds_doc_file":"https://example.com/image.png",
+						"selfie_file":"https://example.com/image.png",
+						"purpose_of_transactions":"investment_purposes",
+						"purpose_of_transactions_explanation":"Investing in stocks",
+						"tos_id":"to_nppX66ntvtHs",
+						"created_at":"2022-02-02T00:00:00.000Z",
+						"updated_at":"2022-02-02T00:00:00.000Z",
+						"limit":{
+							"per_transaction":50000,
+							"daily":100000,
+							"monthly":500000
+						}
+					},
+					{
+						"id":"re_IOxAUL24LG7P",
+						"type":"business",
+						"kyc_type":"standard",
+						"kyc_status":"pending",
+						"kyc_warnings":null,
+						"email":"business@example.com",
+						"tax_id":"20096178000195",
+						"address_line_1":"1 King St W",
+						"address_line_2":"Suite 100",
+						"city":"Toronto",
+						"state_province_region":"ON",
+						"country":"CA",
+						"postal_code":"M5H 1A1",
+						"ip_address":null,
+						"image_url":null,
+						"phone_number":"+14165555555",
+						"proof_of_address_doc_type":"UTILITY_BILL",
+						"proof_of_address_doc_file":"https://example.com/image.png",
+						"legal_name":"Business Corp",
+						"alternate_name":"BizCo",
+						"formation_date":"2010-01-01T00:00:00.000Z",
+						"website":"https://businesscorp.com",
+						"owners":[
+							{
+								"role":"beneficial_owner",
+								"first_name":"Carlos",
+								"last_name":"Silva",
+								"date_of_birth":"1995-05-15T00:00:00.000Z",
+								"tax_id":"12345678901",
+								"address_line_1":"Rua Augusta, 1500",
+								"address_line_2":null,
+								"city":"São Paulo",
+								"state_province_region":"SP",
+								"country":"BR",
+								"postal_code":"01304-001",
+								"id_doc_country":"BR",
+								"id_doc_type":"PASSPORT",
+								"id_doc_front_file":"https://example.com/image.png",
+								"id_doc_back_file":"https://example.com/image.png",
+								"proof_of_address_doc_type":"UTILITY_BILL",
+								"proof_of_address_doc_file":"https://example.com/image.png",
+								"id":"ub_000000000000",
+								"instance_id":"in_000000000000",
+								"customer_id":"re_IOxAUL24LG7P"
+							}
+						],
+						"incorporation_doc_file":"https://example.com/image.png",
+						"proof_of_ownership_doc_file":"https://example.com/image.png",
+						"external_id":null,
+						"instance_id":"in_000000000002",
+						"tos_id":"to_nppX66ntvtHs",
+						"aiprise_validation_key":"",
+						"created_at":"2015-03-15T00:00:00.000Z",
+						"updated_at":"2015-03-15T00:00:00.000Z",
+						"limit":{
+							"per_transaction":200000,
+							"daily":400000,
+							"monthly":2000000
+						}
+					}
+				]`),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/customers", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	customers, err := client.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, customers, 3)
+	require.Equal(t, "re_Euw7HN4OdxPn", customers[0].ID)
+	require.Equal(t, "Bernardo", customers[0].FirstName)
+	require.Equal(t, "re_YuaMcI2B8zbQ", customers[1].ID)
+	require.Equal(t, "Alice", customers[1].FirstName)
+	require.Equal(t, "re_IOxAUL24LG7P", customers[2].ID)
+	require.Equal(t, "Business Corp", customers[2].LegalName)
+}
+
+func TestCustomers_CreateIndividualWithStandardKYC(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_Euw7HN4OdxPn"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, customerID)),
+				Method: http.MethodPost,
+				Path:   fmt.Sprintf("/instances/%s/customers", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	addressLine2 := "Apto 101"
+	phoneNumber := "+5511987654321"
+	idDocBackFile := "https://example.com/image.png"
+	response, err := client.CreateIndividualWithStandardKYC(context.Background(), &CreateIndividualStandardParams{
+		Email:                 "bernardo.simonassi@gmail.com",
+		FirstName:             "Bernardo",
+		LastName:              "Simonassi",
+		DateOfBirth:           "1998-02-02T00:00:00.000Z",
+		TaxID:                 "12345678900",
+		AddressLine1:          "Av. Paulista, 1000",
+		AddressLine2:          &addressLine2,
+		City:                  "São Paulo",
+		StateProvinceRegion:   "SP",
+		Country:               types.CountryBR,
+		PostalCode:            "01310-100",
+		PhoneNumber:           &phoneNumber,
+		IDDocCountry:          types.CountryBR,
+		IDDocType:             IdentificationDocumentPassport,
+		IDDocFrontFile:        "https://example.com/image.png",
+		IDDocBackFile:         &idDocBackFile,
+		ProofOfAddressDocType: ProofOfAddressDocTypeUtilityBill,
+		ProofOfAddressDocFile: "https://example.com/image.png",
+		TosID:                 "to_tPiz4bM2nh5K",
+	})
+	require.NoError(t, err)
+	require.Equal(t, customerID, response.ID)
+}
+
+func TestCustomers_CreateIndividualWithEnhancedKYC(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, customerID)),
+				Method: http.MethodPost,
+				Path:   fmt.Sprintf("/instances/%s/customers", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	addressLine2 := "Apto 101"
+	phoneNumber := "+5511987654321"
+	idDocBackFile := "https://example.com/image.png"
+	purposeExplanation := "I am receiving salary payments from my employer"
+	response, err := client.CreateIndividualWithEnhancedKYC(context.Background(), &CreateIndividualEnhancedParams{
+		Email:                            "bernardo.simonassi@gmail.com",
+		FirstName:                        "Bernardo",
+		LastName:                         "Simonassi",
+		DateOfBirth:                      "1998-02-02T00:00:00.000Z",
+		TaxID:                            "12345678900",
+		AddressLine1:                     "Av. Paulista, 1000",
+		AddressLine2:                     &addressLine2,
+		City:                             "São Paulo",
+		StateProvinceRegion:              "SP",
+		Country:                          types.CountryBR,
+		PostalCode:                       "01310-100",
+		PhoneNumber:                      &phoneNumber,
+		IDDocCountry:                     types.CountryBR,
+		IDDocType:                        IdentificationDocumentPassport,
+		IDDocFrontFile:                   "https://example.com/image.png",
+		IDDocBackFile:                    &idDocBackFile,
+		ProofOfAddressDocType:            ProofOfAddressDocTypeUtilityBill,
+		ProofOfAddressDocFile:            "https://example.com/image.png",
+		SelfieFile:                       "https://example.com/image.png",
+		PurposeOfTransactions:            PurposePersonalOrLivingExpenses,
+		SourceOfFundsDocType:             SourceOfFundsSavings,
+		PurposeOfTransactionsExplanation: &purposeExplanation,
+		SourceOfFundsDocFile:             "https://example.com/image.png",
+		TosID:                            "to_3ZZhllJkvo5Z",
+	})
+	require.NoError(t, err)
+	require.Equal(t, customerID, response.ID)
+}
+
+func TestCustomers_CreateBusinessWithStandardKYB(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_IOxAUL24LG7P"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, customerID)),
+				Method: http.MethodPost,
+				Path:   fmt.Sprintf("/instances/%s/customers", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	addressLine2 := "Sala 1201"
+	website := "https://site.com/"
+	ownerIDDocBackFile := "https://example.com/image.png"
+	response, err := client.CreateBusinessWithStandardKYB(context.Background(), &CreateBusinessStandardParams{
+		Email:                   "contato@empresa.com.br",
+		TaxID:                   "20096178000195",
+		AddressLine1:            "Av. Brigadeiro Faria Lima, 400",
+		AddressLine2:            &addressLine2,
+		City:                    "São Paulo",
+		StateProvinceRegion:     "SP",
+		Country:                 types.CountryBR,
+		PostalCode:              "04538-132",
+		LegalName:               "Empresa Exemplo Ltda",
+		AlternateName:           "Exemplo",
+		FormationDate:           "2010-05-20T00:00:00.000Z",
+		IncorporationDocFile:    "https://example.com/image.png",
+		ProofOfAddressDocType:   ProofOfAddressDocTypeUtilityBill,
+		ProofOfAddressDocFile:   "https://example.com/image.png",
+		ProofOfOwnershipDocFile: "https://example.com/image.png",
+		Website:                 &website,
+		Owners: []Owner{
+			{
+				Role:                  "beneficial_owner",
+				FirstName:             "Carlos",
+				LastName:              "Silva",
+				DateOfBirth:           "1995-05-15T00:00:00.000Z",
+				TaxID:                 "12345678901",
+				AddressLine1:          "Rua Augusta, 1500",
+				AddressLine2:          nil,
+				City:                  "São Paulo",
+				StateProvinceRegion:   "SP",
+				Country:               types.CountryBR,
+				PostalCode:            "01304-001",
+				IDDocCountry:          types.CountryBR,
+				IDDocType:             IdentificationDocumentPassport,
+				IDDocFrontFile:        "https://example.com/image.png",
+				IDDocBackFile:         &ownerIDDocBackFile,
+				ProofOfAddressDocType: ProofOfAddressDocTypeUtilityBill,
+				ProofOfAddressDocFile: "https://example.com/image.png",
+				ID:                    "ub_000000000000",
+				InstanceID:            "in_000000000000",
+				CustomerID:            "re_IOxAUL24LG7P",
+			},
+		},
+		TosID: "to_nppX66ntvtHs",
+	})
+	require.NoError(t, err)
+	require.Equal(t, customerID, response.ID)
+}
+
+func TestCustomers_Get(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(`{
+					"id":"re_YuaMcI2B8zbQ",
+					"type":"individual",
+					"kyc_type":"enhanced",
+					"kyc_status":"verifying",
+					"kyc_warnings":[
+						{
+							"code":null,
+							"message":null,
+							"resolution_status":null,
+							"warning_id":null
+						}
+					],
+					"email":"bernardo.simonassi@gmail.com",
+					"tax_id":"12345678900",
+					"address_line_1":"Av. Paulista, 1000",
+					"address_line_2":"Apto 101",
+					"city":"São Paulo",
+					"state_province_region":"SP",
+					"country":"BR",
+					"postal_code":"01310-100",
+					"ip_address":"127.0.0.1",
+					"image_url":"https://example.com/image.png",
+					"phone_number":"+5511987654321",
+					"proof_of_address_doc_type":"UTILITY_BILL",
+					"proof_of_address_doc_file":"https://example.com/image.png",
+					"first_name":"Bernardo",
+					"last_name":"Simonassi",
+					"date_of_birth":"1998-02-02T00:00:00.000Z",
+					"id_doc_country":"BR",
+					"id_doc_type":"PASSPORT",
+					"id_doc_front_file":"https://example.com/image.png",
+					"id_doc_back_file":"https://example.com/image.png",
+					"aiprise_validation_key":"",
+					"source_of_funds_doc_type":"savings",
+					"source_of_funds_doc_file":"https://example.com/image.png",
+					"selfie_file":"https://example.com/image.png",
+					"purpose_of_transactions":"personal_or_living_expenses",
+					"purpose_of_transactions_explanation":"I am receiving salary payments from my employer",
+					"instance_id":"in_000000000000",
+					"tos_id":"to_3ZZhllJkvo5Z",
+					"created_at":"2021-01-01T00:00:00.000Z",
+					"updated_at":"2021-01-01T00:00:00.000Z",
+					"limit":{
+						"per_transaction":100000,
+						"daily":200000,
+						"monthly":1000000
+					}
+				}`),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/customers/%s", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	customer, err := client.Get(context.Background(), customerID)
+	require.NoError(t, err)
+	require.Equal(t, customerID, customer.ID)
+	require.Equal(t, "Bernardo", customer.FirstName)
+	require.Equal(t, "Simonassi", customer.LastName)
+}
+
+func TestCustomers_Update(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+	newEmail := "bernardo.simonassi@gmail.com"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(`{"data":null}`),
+				Method: http.MethodPut,
+				Path:   fmt.Sprintf("/instances/%s/customers/%s", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	err := client.Update(context.Background(), &UpdateParams{
+		CustomerID: customerID,
+		Email:      &newEmail,
+	})
+	require.NoError(t, err)
+}
+
+func TestCustomers_Delete(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(`{"data":null}`),
+				Method: http.MethodDelete,
+				Path:   fmt.Sprintf("/instances/%s/customers/%s", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	err := client.Delete(context.Background(), customerID)
+	require.NoError(t, err)
+}
+
+func TestCustomers_GetLimits(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(`{
+					"limits":{
+						"payin":{
+							"daily":10000,
+							"monthly":50000
+						},
+						"payout":{
+							"daily":20000,
+							"monthly":100000
+						}
+					}
+				}`),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/limits/customers/%s", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	limits, err := client.GetLimits(context.Background(), customerID)
+	require.NoError(t, err)
+	require.Equal(t, 10000.0, limits.Limits.Payin.Daily)
+	require.Equal(t, 20000.0, limits.Limits.Payout.Daily)
+}
+
+func TestCustomers_GetLimitIncreaseRequests(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(`[
+					{
+						"id": "rl_000000000000",
+						"customer_id": "re_YuaMcI2B8zbQ",
+						"status": "in_review",
+						"daily": 50000,
+						"monthly": 250000,
+						"per_transaction": 25000,
+						"supporting_document_file": "https://example.com/bank-statement.pdf",
+						"supporting_document_type": "individual_bank_statement",
+						"created_at": "2025-01-15T10:30:00.000Z",
+						"updated_at": "2025-01-15T10:30:00.000Z"
+					},
+					{
+						"id": "rl_000000000001",
+						"customer_id": "re_YuaMcI2B8zbQ",
+						"status": "approved",
+						"daily": 30000,
+						"monthly": 150000,
+						"per_transaction": 15000,
+						"approved_per_transaction": 10000,
+						"approved_daily": 20000,
+						"approved_monthly": 100000,
+						"supporting_document_file": "https://example.com/proof-of-income.pdf",
+						"supporting_document_type": "individual_proof_of_income",
+						"created_at": "2024-12-10T14:20:00.000Z",
+						"updated_at": "2024-12-12T09:45:00.000Z"
+					}
+				]`),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/limit-increase", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	requests, err := client.GetLimitIncreaseRequests(context.Background(), customerID)
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	require.Equal(t, "rl_000000000000", requests[0].ID)
+	require.Equal(t, customerID, requests[0].CustomerID)
+	require.Equal(t, LimitIncreaseRequestStatusInReview, requests[0].Status)
+	require.Equal(t, 50000.0, requests[0].Daily)
+	require.Equal(t, 250000.0, requests[0].Monthly)
+	require.Equal(t, 25000.0, requests[0].PerTransaction)
+	require.Equal(t, "https://example.com/bank-statement.pdf", requests[0].SupportingDocumentFile)
+	require.Equal(t, LimitIncreaseRequestSupportingDocumentTypeIndividualBankStatement, requests[0].SupportingDocumentType)
+	require.Equal(t, "rl_000000000001", requests[1].ID)
+	require.Equal(t, LimitIncreaseRequestStatusApproved, requests[1].Status)
+	require.NotNil(t, requests[1].ApprovedPerTransaction)
+	require.Equal(t, 10000, *requests[1].ApprovedPerTransaction)
+	require.NotNil(t, requests[1].ApprovedDaily)
+	require.Equal(t, 20000, *requests[1].ApprovedDaily)
+	require.NotNil(t, requests[1].ApprovedMonthly)
+	require.Equal(t, 100000, *requests[1].ApprovedMonthly)
+	require.Nil(t, requests[0].ApprovedPerTransaction)
+	require.Nil(t, requests[0].ApprovedDaily)
+	require.Nil(t, requests[0].ApprovedMonthly)
+}
+
+func TestCustomers_RequestLimitIncrease(t *testing.T) {
+	instanceID := "in_000000000000"
+	customerID := "re_YuaMcI2B8zbQ"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(`{"id": "rl_000000000000"}`),
+				Method: http.MethodPost,
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/limit-increase", instanceID, customerID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	response, err := client.RequestLimitIncrease(context.Background(), &RequestLimitIncreaseParams{
+		CustomerID:             customerID,
+		Daily:                  100000,
+		Monthly:                500000,
+		PerTransaction:         50000,
+		SupportingDocumentFile: "https://example.com/tax-return.pdf",
+		SupportingDocumentType: LimitIncreaseRequestSupportingDocumentTypeIndividualTaxReturn,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "rl_000000000000", response.ID)
+}
+
+func TestCustomers_ListWithParams(t *testing.T) {
+	instanceID := "in_000000000000"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test_key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(`{
+					"data": [
+						{
+							"id":"re_Euw7HN4OdxPn",
+							"type":"individual",
+							"kyc_type":"standard",
+							"kyc_status":"approved",
+							"email":"bernardo@gmail.com",
+							"country":"BR",
+							"instance_id":"in_000000000000",
+							"limit":{
+								"per_transaction":100000,
+								"daily":200000,
+								"monthly":1000000
+							}
+						}
+					],
+					"pagination": {
+						"has_more": false,
+						"next_page": 0,
+						"prev_page": 0
+					}
+				}`),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/customers", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	result, err := client.ListWithParams(context.Background(), &ListParams{
+		Limit:  "10",
+		Status: KycStatusApproved,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Data, 1)
+	require.Equal(t, "re_Euw7HN4OdxPn", result.Data[0].ID)
+	require.Equal(t, false, result.Pagination.HasMore)
+}

--- a/instances/client.go
+++ b/instances/client.go
@@ -48,6 +48,16 @@ type UpdateMemberRoleParams struct {
 	Role     InstanceMemberRole `json:"user_role"`
 }
 
+// MigrateOwnershipParams represents parameters for migrating instance ownership.
+type MigrateOwnershipParams struct {
+	UserID string `json:"user_id"`
+}
+
+// MigrateOwnershipResponse represents the response when migrating instance ownership.
+type MigrateOwnershipResponse struct {
+	Success bool `json:"success"`
+}
+
 // Client handles instance-related operations.
 type Client struct {
 	cfg        *request.Config
@@ -129,4 +139,17 @@ func (c *Client) UpdateMemberRole(ctx context.Context, params *UpdateMemberRoleP
 
 	_, err := request.Do[struct{}](c.cfg, ctx, "PUT", path, body)
 	return err
+}
+
+// MigrateOwnership migrates instance ownership to another user.
+func (c *Client) MigrateOwnership(ctx context.Context, params *MigrateOwnershipParams) (*MigrateOwnershipResponse, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+	if params.UserID == "" {
+		return nil, fmt.Errorf("user ID cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/ownership", c.instanceID)
+	return request.Do[*MigrateOwnershipResponse](c.cfg, ctx, "POST", path, params)
 }

--- a/payins/client.go
+++ b/payins/client.go
@@ -94,7 +94,6 @@ type ListParams struct {
 	Offset     int                     `json:"offset,omitempty"`
 }
 
-
 // CreateEvmResponse represents the response when creating an EVM payin.
 type CreateEvmResponse struct {
 	ID                  string                     `json:"id"`

--- a/payins/client.go
+++ b/payins/client.go
@@ -94,11 +94,6 @@ type ListParams struct {
 	Offset     int                     `json:"offset,omitempty"`
 }
 
-// ListResponse represents the response when listing payins.
-type ListResponse struct {
-	Data       []Payin                  `json:"data"`
-	Pagination types.PaginationMetadata `json:"pagination"`
-}
 
 // CreateEvmResponse represents the response when creating an EVM payin.
 type CreateEvmResponse struct {
@@ -135,7 +130,7 @@ func NewClient(cfg *config.Config) *Client {
 }
 
 // List retrieves all payins with optional filters.
-func (c *Client) List(ctx context.Context, params *ListParams) (*ListResponse, error) {
+func (c *Client) List(ctx context.Context, params *ListParams) ([]Payin, error) {
 	path := fmt.Sprintf("/instances/%s/payins", c.instanceID)
 
 	if params != nil {
@@ -157,7 +152,7 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*ListResponse, e
 		}
 	}
 
-	return request.Do[*ListResponse](c.cfg, ctx, "GET", path, nil)
+	return request.Do[[]Payin](c.cfg, ctx, "GET", path, nil)
 }
 
 // Get retrieves a specific payin by ID.

--- a/payins/payins_test.go
+++ b/payins/payins_test.go
@@ -23,10 +23,9 @@ func TestPayins_List(t *testing.T) {
 		HTTPClient: &http.Client{
 			Transport: &blindpaytest.RoundTripper{
 				T: t,
-				Out: json.RawMessage(`{
-					"data": [
-						{
-							"receiver_id": "re_000000000000",
+				Out: json.RawMessage(`[
+					{
+						"receiver_id": "re_000000000000",
 							"id": "re_000000000000",
 							"pix_code":"00020101021226790014br.gov.bcb.pix2557brcode.starkinfra.com/v2/bcf07f6c4110454e9fd6f120bab13e835204000053039865802BR5915Blind Pay, Inc.6010Vila Velha62070503***6304BCAB",
 							"memo_code": "8K45GHBNT6BQ6462",
@@ -108,13 +107,7 @@ func TestPayins_List(t *testing.T) {
 								}
 							}
 						}
-					],
-					"pagination": {
-						"has_more": true,
-						"next_page": 3,
-						"prev_page": 1
-					}
-				}`),
+				]`),
 				Method: http.MethodGet,
 				Path:   fmt.Sprintf("/instances/%s/payins", instanceID),
 			},
@@ -125,9 +118,9 @@ func TestPayins_List(t *testing.T) {
 	client := NewClient(cfg)
 	response, err := client.List(context.Background(), &ListParams{})
 	require.NoError(t, err)
-	require.Len(t, response.Data, 1)
-	require.Equal(t, "re_000000000000", response.Data[0].ID)
-	require.Equal(t, types.TransactionStatusProcessing, response.Data[0].Status)
+	require.Len(t, response, 1)
+	require.Equal(t, "re_000000000000", response[0].ID)
+	require.Equal(t, types.TransactionStatusProcessing, response[0].Status)
 }
 
 func TestPayins_Get(t *testing.T) {

--- a/payouts/client.go
+++ b/payouts/client.go
@@ -93,7 +93,6 @@ type ListParams struct {
 	Offset     int    `json:"offset,omitempty"`
 }
 
-
 // ExportParams represents parameters for exporting payouts.
 type ExportParams struct {
 	Limit  int `json:"limit,omitempty"`

--- a/payouts/client.go
+++ b/payouts/client.go
@@ -93,11 +93,6 @@ type ListParams struct {
 	Offset     int    `json:"offset,omitempty"`
 }
 
-// ListResponse represents the response when listing payouts.
-type ListResponse struct {
-	Data       []Payout                 `json:"data"`
-	Pagination types.PaginationMetadata `json:"pagination"`
-}
 
 // ExportParams represents parameters for exporting payouts.
 type ExportParams struct {
@@ -176,7 +171,7 @@ func NewClient(cfg *config.Config) *Client {
 }
 
 // List retrieves all payouts with optional filters.
-func (c *Client) List(ctx context.Context, params *ListParams) (*ListResponse, error) {
+func (c *Client) List(ctx context.Context, params *ListParams) ([]Payout, error) {
 	path := fmt.Sprintf("/instances/%s/payouts", c.instanceID)
 
 	if params != nil {
@@ -195,7 +190,7 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*ListResponse, e
 		}
 	}
 
-	return request.Do[*ListResponse](c.cfg, ctx, "GET", path, nil)
+	return request.Do[[]Payout](c.cfg, ctx, "GET", path, nil)
 }
 
 // Export retrieves all payouts for export with optional pagination.

--- a/payouts/payouts_test.go
+++ b/payouts/payouts_test.go
@@ -23,10 +23,9 @@ func TestPayouts_List(t *testing.T) {
 		HTTPClient: &http.Client{
 			Transport: &blindpaytest.RoundTripper{
 				T: t,
-				Out: json.RawMessage(`{
-					"data":[
-						{
-							"receiver_id":"re_000000000000",
+				Out: json.RawMessage(`[
+					{
+						"receiver_id":"re_000000000000",
 							"id":"pa_000000000000",
 							"status":"processing",
 							"sender_wallet_address":"0x123...890",
@@ -116,14 +115,8 @@ func TestPayouts_List(t *testing.T) {
 							"transfers_account":"BM123123123123",
 							"transfers_type":"CVU",
 							"has_virtual_account":true
-						}
-					],
-					"pagination":{
-						"has_more":true,
-						"next_page":3,
-						"prev_page":1
 					}
-				}`),
+				]`),
 				Method: http.MethodGet,
 				Path:   fmt.Sprintf("/instances/%s/payouts", instanceID),
 			},
@@ -134,9 +127,9 @@ func TestPayouts_List(t *testing.T) {
 	client := NewClient(cfg)
 	response, err := client.List(context.Background(), &ListParams{})
 	require.NoError(t, err)
-	require.Len(t, response.Data, 1)
-	require.Equal(t, "pa_000000000000", response.Data[0].ID)
-	require.Equal(t, types.TransactionStatusProcessing, response.Data[0].Status)
+	require.Len(t, response, 1)
+	require.Equal(t, "pa_000000000000", response[0].ID)
+	require.Equal(t, types.TransactionStatusProcessing, response[0].Status)
 }
 
 func TestPayouts_Export(t *testing.T) {

--- a/virtualaccounts/client.go
+++ b/virtualaccounts/client.go
@@ -50,7 +50,7 @@ type VirtualAccount struct {
 
 // CreateParams represents parameters for creating a virtual account.
 type CreateParams struct {
-	ReceiverID            string                `json:"-"`
+	CustomerID            string                `json:"-"`
 	BlockchainWalletID    string                `json:"blockchain_wallet_id"`
 	Token                 types.StablecoinToken `json:"token"`
 	BankingPartner        types.BankingPartner  `json:"banking_partner"`
@@ -60,7 +60,7 @@ type CreateParams struct {
 
 // UpdateParams represents parameters for updating a virtual account.
 type UpdateParams struct {
-	ReceiverID         string                `json:"-"`
+	CustomerID         string                `json:"-"`
 	VirtualAccountID   string                `json:"-"`
 	BlockchainWalletID string                `json:"blockchain_wallet_id"`
 	Token              types.StablecoinToken `json:"token"`
@@ -91,11 +91,11 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*VirtualAcco
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts", c.instanceID, params.CustomerID)
 
 	body := struct {
 		BlockchainWalletID    string                `json:"blockchain_wallet_id"`
@@ -115,25 +115,25 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*VirtualAcco
 }
 
 // Get retrieves a virtual account by ID.
-func (c *Client) Get(ctx context.Context, receiverID, virtualAccountID string) (*VirtualAccount, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Get(ctx context.Context, customerID, virtualAccountID string) (*VirtualAccount, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if virtualAccountID == "" {
 		return nil, fmt.Errorf("virtual account ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts/%s", c.instanceID, receiverID, virtualAccountID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts/%s", c.instanceID, customerID, virtualAccountID)
 	return request.Do[*VirtualAccount](c.cfg, ctx, "GET", path, nil)
 }
 
-// List retrieves all virtual accounts for a receiver.
-func (c *Client) List(ctx context.Context, receiverID string) ([]VirtualAccount, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+// List retrieves all virtual accounts for a customer.
+func (c *Client) List(ctx context.Context, customerID string) ([]VirtualAccount, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts", c.instanceID, receiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts", c.instanceID, customerID)
 	return request.Do[[]VirtualAccount](c.cfg, ctx, "GET", path, nil)
 }
 
@@ -142,14 +142,14 @@ func (c *Client) Update(ctx context.Context, params *UpdateParams) error {
 	if params == nil {
 		return fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
 	}
 	if params.VirtualAccountID == "" {
 		return fmt.Errorf("virtual account ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts/%s", c.instanceID, params.ReceiverID, params.VirtualAccountID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts/%s", c.instanceID, params.CustomerID, params.VirtualAccountID)
 
 	body := struct {
 		BlockchainWalletID string                `json:"blockchain_wallet_id"`

--- a/virtualaccounts/virtualaccounts_test.go
+++ b/virtualaccounts/virtualaccounts_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVirtualAccounts_Create(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 	id := "va_000000000000"
 	walletID := "bw_000000000000"
@@ -67,7 +67,7 @@ func TestVirtualAccounts_Create(t *testing.T) {
 				In:     json.RawMessage(inJson),
 				Out:    json.RawMessage(outJson),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -75,7 +75,7 @@ func TestVirtualAccounts_Create(t *testing.T) {
 
 	client := NewClient(cfg)
 	account, err := client.Create(context.Background(), &CreateParams{
-		ReceiverID:         receiverID,
+		CustomerID:         customerID,
 		BlockchainWalletID: walletID,
 		Token:              types.StablecoinTokenUSDC,
 		BankingPartner:     types.BankingPartnerCfsb,
@@ -86,7 +86,7 @@ func TestVirtualAccounts_Create(t *testing.T) {
 }
 
 func TestVirtualAccounts_Get(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 	id := "va_000000000000"
 	walletID := "bw_000000000000"
@@ -132,21 +132,21 @@ func TestVirtualAccounts_Get(t *testing.T) {
 				T:      t,
 				Out:    json.RawMessage(outJson),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts/%s", instanceID, receiverID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts/%s", instanceID, customerID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	account, err := client.Get(context.Background(), receiverID, id)
+	account, err := client.Get(context.Background(), customerID, id)
 	require.NoError(t, err)
 	require.Equal(t, id, account.ID)
 	require.Equal(t, walletID, account.BlockchainWalletID)
 }
 
 func TestVirtualAccounts_Update(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 	virtualAccountID := "va_000000000000"
 	newWalletID := "bw_000000000000"
@@ -167,7 +167,7 @@ func TestVirtualAccounts_Update(t *testing.T) {
 				In:     json.RawMessage(inJson),
 				Out:    json.RawMessage(outJson),
 				Method: http.MethodPut,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/virtual-accounts/%s", instanceID, receiverID, virtualAccountID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/virtual-accounts/%s", instanceID, customerID, virtualAccountID),
 			},
 		},
 		UserAgent: "test",
@@ -175,7 +175,7 @@ func TestVirtualAccounts_Update(t *testing.T) {
 
 	client := NewClient(cfg)
 	err := client.Update(context.Background(), &UpdateParams{
-		ReceiverID:         receiverID,
+		CustomerID:         customerID,
 		VirtualAccountID:   virtualAccountID,
 		BlockchainWalletID: newWalletID,
 		Token:              types.StablecoinTokenUSDC,

--- a/wallets/client.go
+++ b/wallets/client.go
@@ -18,7 +18,7 @@ type BlockchainWallet struct {
 	Address              string        `json:"address,omitempty"`
 	SignatureTxHash      string        `json:"signature_tx_hash,omitempty"`
 	IsAccountAbstraction bool          `json:"is_account_abstraction"`
-	ReceiverID           string        `json:"receiver_id"`
+	CustomerID           string        `json:"customer_id"`
 }
 
 // GetMessageResponse represents the wallet message response.
@@ -28,7 +28,7 @@ type GetMessageResponse struct {
 
 // CreateWithAddressParams represents parameters for creating a wallet with address.
 type CreateWithAddressParams struct {
-	ReceiverID string        `json:"receiver_id"`
+	CustomerID string        `json:"customer_id"`
 	Name       string        `json:"name"`
 	Network    types.Network `json:"network"`
 	Address    string        `json:"address"`
@@ -36,7 +36,7 @@ type CreateWithAddressParams struct {
 
 // CreateWithHashParams represents parameters for creating a wallet with hash.
 type CreateWithHashParams struct {
-	ReceiverID      string        `json:"receiver_id"`
+	CustomerID      string        `json:"customer_id"`
 	Name            string        `json:"name"`
 	Network         types.Network `json:"network"`
 	SignatureTxHash string        `json:"signature_tx_hash"`
@@ -94,13 +94,13 @@ func NewClient(cfg *config.Config) *Client {
 	}
 }
 
-// List retrieves all blockchain wallets for a receiver.
-func (c *Client) List(ctx context.Context, receiverID string) ([]BlockchainWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+// List retrieves all blockchain wallets for a customer.
+func (c *Client) List(ctx context.Context, customerID string) ([]BlockchainWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets", c.instanceID, receiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets", c.instanceID, customerID)
 	return request.Do[[]BlockchainWallet](c.cfg, ctx, "GET", path, nil)
 }
 
@@ -109,11 +109,11 @@ func (c *Client) CreateWithAddress(ctx context.Context, params *CreateWithAddres
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets", c.instanceID, params.CustomerID)
 
 	body := struct {
 		Name                 string        `json:"name"`
@@ -135,11 +135,11 @@ func (c *Client) CreateWithHash(ctx context.Context, params *CreateWithHashParam
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets", c.instanceID, params.ReceiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets", c.instanceID, params.CustomerID)
 
 	body := struct {
 		Name                 string        `json:"name"`
@@ -157,38 +157,38 @@ func (c *Client) CreateWithHash(ctx context.Context, params *CreateWithHashParam
 }
 
 // GetWalletMessage retrieves the wallet message for signing.
-func (c *Client) GetWalletMessage(ctx context.Context, receiverID string) (*GetMessageResponse, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) GetWalletMessage(ctx context.Context, customerID string) (*GetMessageResponse, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/sign-message", c.instanceID, receiverID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/sign-message", c.instanceID, customerID)
 	return request.Do[*GetMessageResponse](c.cfg, ctx, "GET", path, nil)
 }
 
 // Get retrieves a specific blockchain wallet.
-func (c *Client) Get(ctx context.Context, receiverID, id string) (*BlockchainWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Get(ctx context.Context, customerID, id string) (*BlockchainWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return nil, fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/%s", c.instanceID, customerID, id)
 	return request.Do[*BlockchainWallet](c.cfg, ctx, "GET", path, nil)
 }
 
 // Delete deletes a blockchain wallet.
-func (c *Client) Delete(ctx context.Context, receiverID, id string) error {
-	if receiverID == "" {
-		return fmt.Errorf("receiver ID cannot be empty")
+func (c *Client) Delete(ctx context.Context, customerID, id string) error {
+	if customerID == "" {
+		return fmt.Errorf("customer ID cannot be empty")
 	}
 	if id == "" {
 		return fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/%s", c.instanceID, receiverID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/%s", c.instanceID, customerID, id)
 	_, err := request.Do[struct{}](c.cfg, ctx, "DELETE", path, nil)
 	return err
 }
@@ -245,7 +245,7 @@ type OfframpWallet struct {
 	ID            string    `json:"id"`
 	ExternalID    string    `json:"external_id"`
 	InstanceID    string    `json:"instance_id"`
-	ReceiverID    string    `json:"receiver_id"`
+	CustomerID    string    `json:"customer_id"`
 	BankAccountID string    `json:"bank_account_id"`
 	Network       string    `json:"network"`
 	Address       string    `json:"address"`
@@ -255,7 +255,7 @@ type OfframpWallet struct {
 
 // CreateOfframpWalletParams represents parameters for creating an offramp wallet.
 type CreateOfframpWalletParams struct {
-	ReceiverID    string `json:"receiver_id"`
+	CustomerID    string `json:"customer_id"`
 	BankAccountID string `json:"bank_account_id"`
 	ExternalID    string `json:"external_id"`
 	Network       string `json:"network"`
@@ -284,16 +284,16 @@ func NewOfframpClient(cfg *config.Config) *OfframpClient {
 }
 
 // List retrieves all offramp wallets for a bank account.
-func (c *OfframpClient) List(ctx context.Context, receiverID, bankAccountID string) ([]OfframpWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *OfframpClient) List(ctx context.Context, customerID, bankAccountID string) ([]OfframpWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if bankAccountID == "" {
 		return nil, fmt.Errorf("bank account ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets",
-		c.instanceID, receiverID, bankAccountID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets",
+		c.instanceID, customerID, bankAccountID)
 	return request.Do[[]OfframpWallet](c.cfg, ctx, "GET", path, nil)
 }
 
@@ -302,15 +302,15 @@ func (c *OfframpClient) Create(ctx context.Context, params *CreateOfframpWalletP
 	if params == nil {
 		return nil, fmt.Errorf("params cannot be nil")
 	}
-	if params.ReceiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+	if params.CustomerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if params.BankAccountID == "" {
 		return nil, fmt.Errorf("bank account ID cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets",
-		c.instanceID, params.ReceiverID, params.BankAccountID)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets",
+		c.instanceID, params.CustomerID, params.BankAccountID)
 
 	body := struct {
 		ExternalID string `json:"external_id"`
@@ -324,9 +324,9 @@ func (c *OfframpClient) Create(ctx context.Context, params *CreateOfframpWalletP
 }
 
 // Get retrieves a specific offramp wallet.
-func (c *OfframpClient) Get(ctx context.Context, receiverID, bankAccountID, id string) (*OfframpWallet, error) {
-	if receiverID == "" {
-		return nil, fmt.Errorf("receiver ID cannot be empty")
+func (c *OfframpClient) Get(ctx context.Context, customerID, bankAccountID, id string) (*OfframpWallet, error) {
+	if customerID == "" {
+		return nil, fmt.Errorf("customer ID cannot be empty")
 	}
 	if bankAccountID == "" {
 		return nil, fmt.Errorf("bank account ID cannot be empty")
@@ -335,7 +335,7 @@ func (c *OfframpClient) Get(ctx context.Context, receiverID, bankAccountID, id s
 		return nil, fmt.Errorf("id cannot be empty")
 	}
 
-	path := fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets/%s",
-		c.instanceID, receiverID, bankAccountID, id)
+	path := fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets/%s",
+		c.instanceID, customerID, bankAccountID, id)
 	return request.Do[*OfframpWallet](c.cfg, ctx, "GET", path, nil)
 }

--- a/wallets/wallets_test.go
+++ b/wallets/wallets_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestWallets_CreateWithAddress(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 	id := "bw_000000000000"
 	address := "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C"
@@ -39,10 +39,10 @@ func TestWallets_CreateWithAddress(t *testing.T) {
 					"address":"0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
 					"signature_tx_hash":null,
 					"is_account_abstraction":true,
-					"receiver_id":"re_000000000000"
+					"customer_id":"re_000000000000"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
@@ -50,7 +50,7 @@ func TestWallets_CreateWithAddress(t *testing.T) {
 
 	client := NewClient(cfg)
 	wallet, err := client.CreateWithAddress(context.Background(), &CreateWithAddressParams{
-		ReceiverID: receiverID,
+		CustomerID: customerID,
 		Name:       "Wallet Display Name",
 		Network:    types.NetworkPolygon,
 		Address:    address,
@@ -62,7 +62,7 @@ func TestWallets_CreateWithAddress(t *testing.T) {
 }
 
 func TestWallets_List(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 
 	cfg := &config.Config{
@@ -80,18 +80,18 @@ func TestWallets_List(t *testing.T) {
 						"address":"0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
 						"signature_tx_hash":"0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
 						"is_account_abstraction":false,
-						"receiver_id":"re_000000000000"
+						"customer_id":"re_000000000000"
 					}
 				]`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	wallets, err := client.List(context.Background(), receiverID)
+	wallets, err := client.List(context.Background(), customerID)
 	require.NoError(t, err)
 	require.Len(t, wallets, 1)
 	require.Equal(t, "bw_000000000000", wallets[0].ID)
@@ -100,11 +100,11 @@ func TestWallets_List(t *testing.T) {
 	require.Equal(t, "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C", wallets[0].Address)
 	require.Equal(t, "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359", wallets[0].SignatureTxHash)
 	require.False(t, wallets[0].IsAccountAbstraction)
-	require.Equal(t, "re_000000000000", wallets[0].ReceiverID)
+	require.Equal(t, "re_000000000000", wallets[0].CustomerID)
 }
 
 func TestWallets_Get(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	id := "bw_000000000000"
 	instanceID := "in_000000000000"
 
@@ -122,17 +122,17 @@ func TestWallets_Get(t *testing.T) {
 					"address":"0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
 					"signature_tx_hash":"0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
 					"is_account_abstraction":false,
-					"receiver_id":"re_000000000000"
+					"customer_id":"re_000000000000"
 				}`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/%s", instanceID, receiverID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/%s", instanceID, customerID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	wallet, err := client.Get(context.Background(), receiverID, id)
+	wallet, err := client.Get(context.Background(), customerID, id)
 	require.NoError(t, err)
 	require.Equal(t, id, wallet.ID)
 	require.Equal(t, "Wallet Display Name", wallet.Name)
@@ -140,11 +140,11 @@ func TestWallets_Get(t *testing.T) {
 	require.Equal(t, "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C", wallet.Address)
 	require.Equal(t, "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359", wallet.SignatureTxHash)
 	require.False(t, wallet.IsAccountAbstraction)
-	require.Equal(t, "re_000000000000", wallet.ReceiverID)
+	require.Equal(t, "re_000000000000", wallet.CustomerID)
 }
 
 func TestWallets_Delete(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	id := "bw_000000000000"
 	instanceID := "in_000000000000"
 
@@ -157,19 +157,19 @@ func TestWallets_Delete(t *testing.T) {
 				T:      t,
 				Out:    json.RawMessage(`{"data":null}`),
 				Method: http.MethodDelete,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/%s", instanceID, receiverID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/%s", instanceID, customerID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	err := client.Delete(context.Background(), receiverID, id)
+	err := client.Delete(context.Background(), customerID, id)
 	require.NoError(t, err)
 }
 
 func TestWallets_GetWalletMessage(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	instanceID := "in_000000000000"
 
 	cfg := &config.Config{
@@ -181,14 +181,14 @@ func TestWallets_GetWalletMessage(t *testing.T) {
 				T:      t,
 				Out:    json.RawMessage(`{"message":"random"}`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/blockchain-wallets/sign-message", instanceID, receiverID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/blockchain-wallets/sign-message", instanceID, customerID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewClient(cfg)
-	response, err := client.GetWalletMessage(context.Background(), receiverID)
+	response, err := client.GetWalletMessage(context.Background(), customerID)
 	require.NoError(t, err)
 	require.Equal(t, "random", response.Message)
 }
@@ -341,7 +341,7 @@ func TestWallets_PrepareSolanaDelegationTransaction(t *testing.T) {
 }
 
 func TestOfframpWallets_List(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	bankAccountID := "ba_000000000000"
 	instanceID := "in_000000000000"
 
@@ -357,7 +357,7 @@ func TestOfframpWallets_List(t *testing.T) {
 						"id":"ow_000000000000",
 						"external_id":"your_external_id",
 						"instance_id":"in_000000000000",
-						"receiver_id":"re_000000000000",
+						"customer_id":"re_000000000000",
 						"bank_account_id":"ba_000000000000",
 						"network":"tron",
 						"address":"TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb",
@@ -366,27 +366,27 @@ func TestOfframpWallets_List(t *testing.T) {
 					}
 				]`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets", instanceID, receiverID, bankAccountID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets", instanceID, customerID, bankAccountID),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewOfframpClient(cfg)
-	wallets, err := client.List(context.Background(), receiverID, bankAccountID)
+	wallets, err := client.List(context.Background(), customerID, bankAccountID)
 	require.NoError(t, err)
 	require.Len(t, wallets, 1)
 	require.Equal(t, "ow_000000000000", wallets[0].ID)
 	require.Equal(t, "your_external_id", wallets[0].ExternalID)
 	require.Equal(t, "in_000000000000", wallets[0].InstanceID)
-	require.Equal(t, "re_000000000000", wallets[0].ReceiverID)
+	require.Equal(t, "re_000000000000", wallets[0].CustomerID)
 	require.Equal(t, "ba_000000000000", wallets[0].BankAccountID)
 	require.Equal(t, "tron", wallets[0].Network)
 	require.Equal(t, "TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb", wallets[0].Address)
 }
 
 func TestOfframpWallets_Create(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	bankAccountID := "ba_000000000000"
 	instanceID := "in_000000000000"
 	externalID := "your_external_id"
@@ -410,7 +410,7 @@ func TestOfframpWallets_Create(t *testing.T) {
 					"address":"TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets", instanceID, receiverID, bankAccountID),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets", instanceID, customerID, bankAccountID),
 			},
 		},
 		UserAgent: "test",
@@ -418,7 +418,7 @@ func TestOfframpWallets_Create(t *testing.T) {
 
 	client := NewOfframpClient(cfg)
 	wallet, err := client.Create(context.Background(), &CreateOfframpWalletParams{
-		ReceiverID:    receiverID,
+		CustomerID:    customerID,
 		BankAccountID: bankAccountID,
 		ExternalID:    externalID,
 		Network:       "tron",
@@ -431,7 +431,7 @@ func TestOfframpWallets_Create(t *testing.T) {
 }
 
 func TestOfframpWallets_Get(t *testing.T) {
-	receiverID := "re_000000000000"
+	customerID := "re_000000000000"
 	bankAccountID := "ba_000000000000"
 	id := "ow_000000000000"
 	instanceID := "in_000000000000"
@@ -447,7 +447,7 @@ func TestOfframpWallets_Get(t *testing.T) {
 					"id":"ow_000000000000",
 					"external_id":"your_external_id",
 					"instance_id":"in_000000000000",
-					"receiver_id":"re_000000000000",
+					"customer_id":"re_000000000000",
 					"bank_account_id":"ba_000000000000",
 					"network":"tron",
 					"address":"TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb",
@@ -455,19 +455,19 @@ func TestOfframpWallets_Get(t *testing.T) {
 					"updated_at":"2021-01-01T00:00:00Z"
 				}`),
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("/instances/%s/receivers/%s/bank-accounts/%s/offramp-wallets/%s", instanceID, receiverID, bankAccountID, id),
+				Path:   fmt.Sprintf("/instances/%s/customers/%s/bank-accounts/%s/offramp-wallets/%s", instanceID, customerID, bankAccountID, id),
 			},
 		},
 		UserAgent: "test",
 	}
 
 	client := NewOfframpClient(cfg)
-	wallet, err := client.Get(context.Background(), receiverID, bankAccountID, id)
+	wallet, err := client.Get(context.Background(), customerID, bankAccountID, id)
 	require.NoError(t, err)
 	require.Equal(t, id, wallet.ID)
 	require.Equal(t, "your_external_id", wallet.ExternalID)
 	require.Equal(t, "in_000000000000", wallet.InstanceID)
-	require.Equal(t, receiverID, wallet.ReceiverID)
+	require.Equal(t, customerID, wallet.CustomerID)
 	require.Equal(t, bankAccountID, wallet.BankAccountID)
 	require.Equal(t, "tron", wallet.Network)
 	require.Equal(t, "TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb", wallet.Address)


### PR DESCRIPTION
## Summary

- Adds `customers` package with full CRUD + limits + limit increase requests
- Switches `bankaccounts`, `virtualaccounts`, `wallets`, `custodialwallets` sub-resource URLs from `/receivers/` to `/customers/`
- Marks `client.Receivers` as `// Deprecated: use Customers instead` — receivers package kept, no breaking change
- Fixes `payouts.List()` and `payins.List()` to return `[]Payout` / `[]Payin` (plain array) — API returns `[...]` not `{ data: [...] }`
- Adds SEPA fields to `bankaccounts` (mirrors node #50)
- Bumps version to `1.14.0`

## Test plan

- [ ] `go test ./...` passes (all packages including `receivers` and `customers`)
- [ ] `client.Customers` field exists on root client
- [ ] `client.Receivers` field still exists with deprecation comment
- [ ] `bankaccounts.List()` returns `[]BankAccount` (plain array)
- [ ] `payouts.List()` / `payins.List()` return plain arrays