### PR TITLE
chore(ci): run api-sync merges on claude-opus-5

### DIFF
--- a/.github/workflows/api-sync.yml
+++ b/.github/workflows/api-sync.yml
@@ -52,7 +52,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-sonnet-4-20250514 --allowedTools "Bash(*),Read,Edit,Write,Glob,Grep"'
+          claude_args: '--model claude-opus-5 --allowedTools "Bash(*),Read,Edit,Write,Glob,Grep"'
           prompt: |
             You are updating this SDK to match API changes. Read CLAUDE.md for this SDK's conventions.
 


### PR DESCRIPTION
The LLM merge step is the quality bottleneck of the whole sync pipeline, and it was pinned to an old Sonnet build. Bumps to claude-opus-5.

Note the pipeline is currently failing on every run since 2026-07-14 for a separate reason: the CLAUDE_CODE_OAUTH_TOKEN secret (set 2026-05-04) appears expired; runs die in ~2s with is_error:true. That needs a token rotation, tracked separately.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs