### PR TITLE
fix(customers): top annual-revenue band carried an extra digit

### DIFF
--- a/blindpay.go
+++ b/blindpay.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Version is the current version of the SDK.
-const Version = "1.18.0"
+const Version = "1.18.1"
 
 // Client is the main BlindPay client.
 type Client struct {

--- a/customers/client.go
+++ b/customers/client.go
@@ -159,7 +159,10 @@ const (
 	EstimatedAnnualRevenue1000000To9999999    EstimatedAnnualRevenue = "1000000_9999999"
 	EstimatedAnnualRevenue10000000To49999999  EstimatedAnnualRevenue = "10000000_49999999"
 	EstimatedAnnualRevenue50000000To249999999 EstimatedAnnualRevenue = "50000000_249999999"
-	EstimatedAnnualRevenue2500000000Plus      EstimatedAnnualRevenue = "2500000000_plus"
+	EstimatedAnnualRevenue250000000Plus       EstimatedAnnualRevenue = "250000000_plus"
+	// Deprecated: the name carried an extra digit and the value the API rejects.
+	// Use EstimatedAnnualRevenue250000000Plus.
+	EstimatedAnnualRevenue2500000000Plus EstimatedAnnualRevenue = "250000000_plus"
 )
 
 // SourceOfWealth represents the source of wealth for a customer.

--- a/customers/revenue_test.go
+++ b/customers/revenue_test.go
@@ -1,0 +1,14 @@
+package customers
+
+import "testing"
+
+func TestEstimatedAnnualRevenueTopBandMatchesWire(t *testing.T) {
+	// The band below ends at 249999999, so the top band is 250 million, and the
+	// spec enum on CreateCustomerIn agrees.
+	if got := string(EstimatedAnnualRevenue250000000Plus); got != "250000000_plus" {
+		t.Fatalf("top band = %q, want 250000000_plus", got)
+	}
+	if got := string(EstimatedAnnualRevenue2500000000Plus); got != "250000000_plus" {
+		t.Fatalf("deprecated alias = %q, want the corrected wire value", got)
+	}
+}


### PR DESCRIPTION
`EstimatedAnnualRevenue2500000000Plus` was `"2500000000_plus"`, 2.5 billion. The spec's enum, on `CreateCustomerIn`, `UpdateCustomerIn`, `CustomerOut` and both customer webhook schemas, is:

```
["0_99999", "100000_999999", "1000000_9999999", "10000000_49999999", "50000000_249999999", "250000000_plus"]
```

250 million is also the only coherent reading, since the band immediately below ends at 249999999. So a business customer in the top revenue band has been sending a value the API rejects. All five SDKs carry the same typo; I am fixing each one.

The correctly named `EstimatedAnnualRevenue250000000Plus` is added, and the old identifier stays as a deprecated alias carrying the corrected value. Removing an exported identifier would break downstream compilation, and leaving it with the old value would keep sending a rejected value, so it points at the right string with a deprecation note explaining why.

Version 1.18.0 to 1.18.1 (patch: no type or shape change, one enum value corrected).

## Proof

- New test asserts both the correct constant and the deprecated alias serialize to `250000000_plus`.
- `gofmt -l .` empty, `go build ./...` clean, `go test ./...` all packages pass, `go run ./cmd/contractcheck` passes, `go run ./cmd/apisync -check` silent exit 0.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs