### PR TITLE
fix(payouts): correct stellar authorize route

### DIFF
--- a/.api-sync/spec-map.json
+++ b/.api-sync/spec-map.json
@@ -229,8 +229,7 @@
     },
     {
       "spec": "PayoutOnStellarAuthorizeIn",
-      "sdk": [{ "file": "payouts/client.go", "symbol": "AuthorizeStellarTokenParams" }],
-      "note": "Spec operation is POST .../payouts/stellar/authorize; SDK calls POST .../payouts/stellar/authorize-token (pre-existing path drift, see cmd/apisync coverage report and PR description; not changed in this PR)."
+      "sdk": [{ "file": "payouts/client.go", "symbol": "AuthorizeStellarTokenParams" }]
     },
     {
       "spec": "SubmitPayoutDocumentsIn",

--- a/.github/workflows/apisync-check.yaml
+++ b/.github/workflows/apisync-check.yaml
@@ -42,8 +42,7 @@ jobs:
           diff -rq /tmp/apisync-proof-a /tmp/apisync-proof-b
 
       # Informational only: spec operations the SDK does not call, and SDK
-      # paths with no matching spec operation (e.g. the known
-      # authorize-token vs authorize drift, and the two spec-absent
+      # paths with no matching spec operation (e.g. the two spec-absent
       # /export/* paths). Never fails the build.
       - name: Spec-operation coverage report (non-blocking)
         run: go run ./cmd/apisync -coverage

--- a/blindpay.go
+++ b/blindpay.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Version is the current version of the SDK.
-const Version = "1.18.1"
+const Version = "1.18.2"
 
 // Client is the main BlindPay client.
 type Client struct {

--- a/cmd/apisync/pathcoverage.go
+++ b/cmd/apisync/pathcoverage.go
@@ -118,8 +118,8 @@ func normalizeSpecPath(p string) string {
 // computeCoverageGaps returns a human-readable, sorted, non-blocking list
 // of (a) spec operations with no matching SDK path literal and (b) SDK path
 // literals with no matching spec operation (e.g. this repo's known
-// pre-existing drift: authorize-token vs authorize, and the two
-// spec-absent /export/* paths). Scope note: this is a path-shape match
+// pre-existing drift: the two spec-absent /export/* paths, which have no
+// corresponding operation in the current public spec). Scope note: this is a path-shape match
 // only (method is not correlated back to the literal, since the SDK builds
 // path variables separately from the request.Do method argument); good
 // enough for a non-blocking survey, not a substitute for the map-validity

--- a/payouts/client.go
+++ b/payouts/client.go
@@ -292,6 +292,6 @@ func (c *Client) AuthorizeStellarToken(ctx context.Context, params *AuthorizeSte
 		return nil, fmt.Errorf("params cannot be nil")
 	}
 
-	path := fmt.Sprintf("/instances/%s/payouts/stellar/authorize-token", c.instanceID)
+	path := fmt.Sprintf("/instances/%s/payouts/stellar/authorize", c.instanceID)
 	return request.Do[*AuthorizeStellarTokenResponse](c.cfg, ctx, "POST", path, params)
 }

--- a/payouts/payouts_test.go
+++ b/payouts/payouts_test.go
@@ -597,7 +597,7 @@ func TestPayouts_AuthorizeStellarToken(t *testing.T) {
 					"transaction_hash":"string"
 				}`),
 				Method: http.MethodPost,
-				Path:   fmt.Sprintf("/instances/%s/payouts/stellar/authorize-token", instanceID),
+				Path:   fmt.Sprintf("/instances/%s/payouts/stellar/authorize", instanceID),
 			},
 		},
 		UserAgent: "test",


### PR DESCRIPTION
## Summary
- Fixes the Stellar payout authorization route: SDK called `POST .../payouts/stellar/authorize-token`, spec operation is `POST .../payouts/stellar/authorize`. Updated the client and test to match, and dropped the now-stale drift notes in `.api-sync/spec-map.json`, `cmd/apisync/pathcoverage.go`, and `apisync-check.yaml`.
- Investigated the reported `/payins/export` and `/payouts/export` route bug: it does not reproduce. The current public spec has no export path (`/v1/instances/{instance_id}/payins/export` or `/payouts/export`) and no export query parameter on the list endpoints. Left the SDK's existing `/export/payins` and `/export/payouts` calls unchanged since there's no spec target to align to; the coverage report still flags them as a known gap.
- Bumped `const Version` to 1.18.2 (patch, bug fix only).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`

Claude-Session: https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs