### PR TITLE
feat(apisync): generate SDK support for new spec operations automatically

### DIFF
--- a/cmd/apisync/golden_test.go
+++ b/cmd/apisync/golden_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// realRepoRoot locates the actual checked-out blindpay-go repo (this test
+// runs from cmd/apisync, so it's two levels up) -- the golden test needs
+// the real partnerfees package and the real committed spec-snapshot.json,
+// not a synthetic fixture, to prove the generator against actual SDK
+// conventions and an actual spec.
+func realRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root := filepath.Join(wd, "..", "..")
+	_, err = os.Stat(filepath.Join(root, "go.mod"))
+	require.NoError(t, err, "expected a go.mod two levels above cmd/apisync")
+	return root
+}
+
+// copyTree recursively copies src into dst, skipping .git (large, and
+// irrelevant to a build/test run).
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if parts := strings.Split(rel, string(filepath.Separator)); len(parts) > 0 && parts[0] == ".git" {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+	require.NoError(t, err)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// TestGolden_OperationInsertRegeneratesDeletedMethods is the operation-
+// insert golden self-test: delete two representative, already-shipped
+// operations from the real SDK (partnerfees.Get, a bare GET, and
+// partnerfees.Create, a POST with a body) along with the structs/tests
+// that belong solely to them, doctor a throwaway copy of the committed
+// snapshot to also not have those two operations (simulating "the SDK is
+// missing operations the spec already has"), then -apply against the
+// real, undoctored snapshot as the target. The generator must reintroduce
+// both routes with the right verb/path/params, the result must build,
+// vet, and test clean, and a second -apply must be a byte-for-byte no-op.
+func TestGolden_OperationInsertRegeneratesDeletedMethods(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	real := realRepoRoot(t)
+	work := t.TempDir()
+	copyTree(t, real, work)
+
+	clientPath := filepath.Join(work, "partnerfees", "client.go")
+	src := readFile(t, clientPath)
+
+	removals := []string{
+		`// CreatePartnerFeeParams represents parameters for creating a partner fee.
+type CreatePartnerFeeParams struct {
+	VirtualAccountSet    *bool   ` + "`json:\"virtual_account_set,omitempty\"`" + `
+	EVMWalletAddress     string  ` + "`json:\"evm_wallet_address\"`" + `
+	Name                 string  ` + "`json:\"name\"`" + `
+	PayinFlatFee         float64 ` + "`json:\"payin_flat_fee\"`" + `
+	PayinPercentageFee   float64 ` + "`json:\"payin_percentage_fee\"`" + `
+	PayoutFlatFee        float64 ` + "`json:\"payout_flat_fee\"`" + `
+	PayoutPercentageFee  float64 ` + "`json:\"payout_percentage_fee\"`" + `
+	StellarWalletAddress *string ` + "`json:\"stellar_wallet_address,omitempty\"`" + `
+}
+
+`,
+		`// Create creates a new partner fee configuration.
+func (c *Client) Create(ctx context.Context, params *CreatePartnerFeeParams) (*PartnerFee, error) {
+	if params == nil {
+		return nil, fmt.Errorf("params cannot be nil")
+	}
+
+	path := fmt.Sprintf("/instances/%s/partner-fees", c.instanceID)
+	return request.Do[*PartnerFee](c.cfg, ctx, "POST", path, params)
+}
+
+`,
+		`// Get retrieves a specific partner fee by ID.
+func (c *Client) Get(ctx context.Context, id string) (*PartnerFee, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id cannot be empty")
+	}
+
+	path := fmt.Sprintf("/instances/%s/partner-fees/%s", c.instanceID, id)
+	return request.Do[*PartnerFee](c.cfg, ctx, "GET", path, nil)
+}
+
+`,
+	}
+	for _, r := range removals {
+		require.Contains(t, src, r, "golden test's removal text is stale against the real partnerfees/client.go source")
+		src = strings.Replace(src, r, "", 1)
+	}
+	writeFile(t, clientPath, src)
+
+	// The Get/Create tests belong solely to the two deleted methods; drop
+	// them (List/Delete's tests are untouched).
+	testPath := filepath.Join(work, "partnerfees", "partnerfees_test.go")
+	writeFile(t, testPath, partnerFeesGoldenTestFile)
+
+	// Doctor a throwaway copy of the committed snapshot: remove the same
+	// two operations, so checkOperationChanges sees them as "new" against
+	// the real, undoctored snapshot passed as -spec below.
+	snapshotPath := filepath.Join(work, ".api-sync", "spec-snapshot.json")
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, snapshotPath)), &spec))
+	paths := spec["paths"].(map[string]any)
+	collection := paths["/v1/instances/{instance_id}/partner-fees"].(map[string]any)
+	byID := paths["/v1/instances/{instance_id}/partner-fees/{id}"].(map[string]any)
+	require.Contains(t, collection, "post")
+	require.Contains(t, byID, "get")
+	delete(collection, "post")
+	delete(byID, "get")
+	doctored, err := json.MarshalIndent(spec, "", "  ")
+	require.NoError(t, err)
+
+	targetSpecPath := filepath.Join(t.TempDir(), "target-spec.json")
+	writeFile(t, targetSpecPath, readFile(t, snapshotPath)) // the real, undoctored spec is the apply target
+	writeFile(t, snapshotPath, string(doctored))            // the doctored copy becomes the committed baseline
+
+	// A pending, un-applied operation-insert must fail -check.
+	_, checkErr := reconcileAndMaybeApply(work, syncOptions{Check: true, SpecPath: targetSpecPath})
+	require.Error(t, checkErr, "an un-applied operation-insert must fail -check")
+
+	quiet, applyErr := reconcileAndMaybeApply(work, syncOptions{Apply: true, SpecPath: targetSpecPath})
+	require.NoError(t, applyErr)
+	require.False(t, quiet)
+
+	regenerated := readFile(t, clientPath)
+	require.Contains(t, regenerated, `func (c *Client) Get(ctx context.Context, id string)`)
+	require.Contains(t, regenerated, `fmt.Sprintf("/instances/%s/partner-fees/%s", c.instanceID, id)`)
+	require.Contains(t, regenerated, `request.Do[*GetResponse](c.cfg, ctx, "GET", path, nil)`)
+	require.Contains(t, regenerated, `func (c *Client) Create(ctx context.Context, params *CreateParams)`)
+	require.Contains(t, regenerated, `fmt.Sprintf("/instances/%s/partner-fees", c.instanceID)`)
+	require.Contains(t, regenerated, `request.Do[*CreateResponse](c.cfg, ctx, "POST", path, params)`)
+
+	blindpayGo := readFile(t, filepath.Join(work, "blindpay.go"))
+	require.Contains(t, blindpayGo, `const Version = "1.19.0"`, "operationSetChanged escalates the bump to minor")
+
+	run := func(name string, args ...string) string {
+		cmd := exec.Command(name, args...)
+		cmd.Dir = work
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s %v failed:\n%s", name, args, string(out))
+		return string(out)
+	}
+	run("go", "build", "./...")
+	run("go", "vet", "./...")
+	// go/vet/test the SDK packages this change actually touches, never
+	// cmd/apisync itself: `work` is a full copy of this very repo, so
+	// running its own apisync test suite in-place would recursively
+	// re-run (and re-copy) this exact golden test against an already-
+	// mutated tree.
+	pkgList := run("go", "list", "./...")
+	var pkgs []string
+	for _, p := range strings.Split(strings.TrimSpace(pkgList), "\n") {
+		if p == "" || strings.Contains(p, "/cmd/") {
+			continue
+		}
+		pkgs = append(pkgs, p)
+	}
+	run("go", append([]string{"test"}, pkgs...)...)
+
+	// Second apply against the same target must be a byte-for-byte no-op.
+	before := readFile(t, clientPath)
+	beforeMap := readFile(t, filepath.Join(work, ".api-sync", "spec-map.json"))
+	beforeVersion := readFile(t, filepath.Join(work, "blindpay.go"))
+
+	quiet, applyErr = reconcileAndMaybeApply(work, syncOptions{Apply: true, SpecPath: targetSpecPath})
+	require.NoError(t, applyErr)
+	require.False(t, quiet) // "nothing to do" is a nil error, not the -check quiet path
+
+	require.Equal(t, before, readFile(t, clientPath), "second -apply must not touch partnerfees/client.go again")
+	require.Equal(t, beforeMap, readFile(t, filepath.Join(work, ".api-sync", "spec-map.json")))
+	require.Equal(t, beforeVersion, readFile(t, filepath.Join(work, "blindpay.go")), "idempotent apply must not bump the version again")
+
+	quiet, checkErr = reconcileAndMaybeApply(work, syncOptions{Check: true, SpecPath: targetSpecPath})
+	require.NoError(t, checkErr)
+	require.True(t, quiet, "-check must now be clean against the (refreshed) snapshot")
+}
+
+// TestGolden_MultipartOperationIsNeedsHuman is the golden test's other
+// half: a synthetic operation on the real partnerfees package's own path
+// prefix, but with a multipart/form-data body -- non-JSON, so the
+// generator must refuse it and leave it to a human, never guess a shape.
+func TestGolden_MultipartOperationIsNeedsHuman(t *testing.T) {
+	real := realRepoRoot(t)
+	work := t.TempDir()
+	copyTree(t, real, work)
+
+	sm, err := loadSpecMap(work)
+	require.NoError(t, err)
+
+	snapshotPath := filepath.Join(work, ".api-sync", "spec-snapshot.json")
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, snapshotPath)), &spec))
+	oldSpecDoc := loadSpecDoc(spec)
+
+	newSpecRaw := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, snapshotPath)), &newSpecRaw))
+	newPaths := newSpecRaw["paths"].(map[string]any)
+	newPaths["/v1/instances/{instance_id}/partner-fees/{id}/logo"] = map[string]any{
+		"post": map[string]any{
+			"tags": []any{"Partner Fees"},
+			"requestBody": map[string]any{"content": map[string]any{"multipart/form-data": map[string]any{
+				"schema": map[string]any{"type": "object", "properties": map[string]any{
+					"file": map[string]any{"type": "string", "format": "binary"},
+				}},
+			}}},
+			"responses": map[string]any{"204": map[string]any{}},
+		},
+	}
+	newSpecDoc := loadSpecDoc(newSpecRaw)
+
+	plan := checkOperationChanges(work, sm, oldSpecDoc, newSpecDoc)
+	require.Empty(t, plan.Actions)
+	require.Len(t, plan.NeedsHuman, 1)
+	require.Contains(t, plan.NeedsHuman[0], "NEEDS_HUMAN")
+	require.Contains(t, plan.NeedsHuman[0], "POST /v1/instances/{instance_id}/partner-fees/{id}/logo")
+	require.Contains(t, plan.NeedsHuman[0], "non-JSON content type")
+	require.Contains(t, plan.NeedsHuman[0], "multipart/form-data")
+}
+
+const partnerFeesGoldenTestFile = `package partnerfees
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/blindpaylabs/blindpay-go/internal/blindpaytest"
+	"github.com/blindpaylabs/blindpay-go/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartnerFees_List(t *testing.T) {
+	instanceID := "in_000000000000"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test-key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T: t,
+				Out: json.RawMessage(` + "`" + `[
+					{
+						"id":"fe_000000000000",
+						"instance_id":"in_000000000000",
+						"name":"Display Name",
+						"payout_percentage_fee":0,
+						"payout_flat_fee":0,
+						"payin_percentage_fee":0,
+						"payin_flat_fee":0,
+						"evm_wallet_address":"0x1234567890123456789012345678901234567890",
+						"stellar_wallet_address":"GAB22222222222222222222222222222222222222222222222222222222222222"
+					}
+				]` + "`" + `),
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/instances/%s/partner-fees", instanceID),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	fees, err := client.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, fees, 1)
+	require.Equal(t, "fe_000000000000", fees[0].ID)
+	require.Equal(t, "Display Name", fees[0].Name)
+}
+
+func TestPartnerFees_Delete(t *testing.T) {
+	instanceID := "in_000000000000"
+	id := "fe_000000000000"
+
+	cfg := &config.Config{
+		BaseURL:    "https://api.blindpay.com",
+		APIKey:     "test-key",
+		InstanceID: instanceID,
+		HTTPClient: &http.Client{
+			Transport: &blindpaytest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(` + "`" + `{"data":null}` + "`" + `),
+				Method: http.MethodDelete,
+				Path:   fmt.Sprintf("/instances/%s/partner-fees/%s", instanceID, id),
+			},
+		},
+		UserAgent: "test",
+	}
+
+	client := NewClient(cfg)
+	err := client.Delete(context.Background(), id)
+	require.NoError(t, err)
+}
+`

--- a/cmd/apisync/main.go
+++ b/cmd/apisync/main.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 func main() {
@@ -129,10 +130,17 @@ func reconcileAndMaybeApply(repoRoot string, opts syncOptions) (quiet bool, err 
 	newSpec := loadSpecDoc(newRaw)
 	oldSpec := loadSpecDoc(oldRaw)
 
+	// checkOperationChanges must run first: its operation-insert actions
+	// register brand-new spec-map.json types[] entries in the same apply
+	// they add the SDK struct for, so checkUnclassifiedSchemas needs its
+	// PendingSchemas to avoid re-flagging those schemas as unclassified
+	// before that registration has actually been written to disk.
+	opPlan := checkOperationChanges(repoRoot, sm, oldSpec, newSpec)
+
 	var needsHuman []string
 	needsHuman = append(needsHuman, checkMapValidity(repoRoot, sm)...)
-	needsHuman = append(needsHuman, checkUnclassifiedSchemas(sm, newSpec)...)
-	needsHuman = append(needsHuman, checkOperationChanges(sm, oldSpec, newSpec)...)
+	needsHuman = append(needsHuman, checkUnclassifiedSchemas(sm, newSpec, opPlan.PendingSchemas)...)
+	needsHuman = append(needsHuman, opPlan.NeedsHuman...)
 	needsHuman = append(needsHuman, checkEnumCoverage(sm, um, newSpec)...)
 	needsHuman = append(needsHuman, checkNestedObjectCoverage(sm, um, newSpec)...)
 
@@ -142,7 +150,7 @@ func reconcileAndMaybeApply(repoRoot string, opts syncOptions) (quiet bool, err 
 	needsHuman = append(needsHuman, typePlan.NeedsHuman...)
 	sort.Strings(needsHuman)
 
-	actions := append(append([]action{}, enumPlan.Actions...), typePlan.Actions...)
+	actions := append(append(append([]action{}, enumPlan.Actions...), typePlan.Actions...), opPlan.Actions...)
 	sort.Slice(actions, func(i, j int) bool { return actions[i].description < actions[j].description })
 
 	gaps := computeCoverageGaps(repoRoot, newSpec)
@@ -197,6 +205,9 @@ func reconcileAndMaybeApply(repoRoot string, opts syncOptions) (quiet bool, err 
 		return false, fmt.Errorf("applying changes: %w", err)
 	}
 	for file := range touchedFiles {
+		if !strings.HasSuffix(file, ".go") {
+			continue // e.g. .api-sync/spec-map.json, patched by operation-insert but not gofmt-able
+		}
 		if err := gofmtFile(filepath.Join(repoRoot, file)); err != nil {
 			return false, fmt.Errorf("gofmt %s: %w", file, err)
 		}

--- a/cmd/apisync/operations.go
+++ b/cmd/apisync/operations.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
@@ -184,35 +183,58 @@ func reachableSchemas(spec *specDoc) map[string]bool {
 	return reachable
 }
 
-// checkOperationChanges hard-fails on any operation added or removed
-// relative to the committed snapshot, unless (for an addition) it belongs
-// to an already-ignored subsystem -- see operationIsIgnored. A brand new
-// operation needs hand-written client wiring (naming, grouping, request/
-// response shape) that a patcher must never invent; silently accepting it
-// is exactly the silent-divergence failure state reconciliation replaced
-// event-diffing to prevent, just one level up from properties/enums.
-func checkOperationChanges(sm *SpecMap, oldSpec, newSpec *specDoc) []string {
+// checkOperationChanges reconciles every operation added or removed
+// relative to the committed snapshot. Removal is always a hard fail.
+// Addition, unless it belongs to an already-ignored subsystem (see
+// operationIsIgnored), is handed to classifyAndPlanOperation: STANDARD
+// (fully generated method + structs + any spec-map.json registrations,
+// via actions) or NON-STANDARD (a precise NEEDS_HUMAN reason -- the
+// generator refuses to guess naming, grouping, or a shape it cannot
+// express, same posture as every other NEEDS_HUMAN in this patcher).
+func checkOperationChanges(repoRoot string, sm *SpecMap, oldSpec, newSpec *specDoc) *planResult {
 	oldOps, newOps := operationEntries(oldSpec), operationEntries(newSpec)
+	p := &planResult{PendingSchemas: map[string]bool{}}
 
-	var issues []string
-	for key, entry := range newOps {
+	newKeys := make([]string, 0, len(newOps))
+	for key := range newOps {
+		newKeys = append(newKeys, key)
+	}
+	sort.Strings(newKeys)
+
+	for _, key := range newKeys {
+		entry := newOps[key]
 		if _, existed := oldOps[key]; existed {
 			continue
 		}
 		if operationIsIgnored(entry, sm) {
 			continue
 		}
-		issues = append(issues, fmt.Sprintf(
-			"NEEDS_HUMAN: new operation %s is not present in the committed snapshot; adding SDK support for a new endpoint needs hand-written client wiring (naming, grouping, request/response shape) that a patcher must not invent (tags=%v)",
-			key, entry.Tags))
-	}
-	for key := range oldOps {
-		if _, stillPresent := newOps[key]; !stillPresent {
-			issues = append(issues, fmt.Sprintf(
-				"NEEDS_HUMAN: operation %s present in the committed snapshot is absent from the target spec (removal is always a hard fail)", key))
+
+		acts, pending, reason := classifyAndPlanOperation(repoRoot, sm, newSpec, entry)
+		if reason != "" {
+			p.addNeedsHuman(
+				"NEEDS_HUMAN: new operation %s is not present in the committed snapshot and the deterministic generator could not classify it as STANDARD (%s); adding SDK support needs hand-written client wiring (naming, grouping, request/response shape) that a patcher must not invent (tags=%v)",
+				key, reason, entry.Tags)
+			continue
+		}
+		p.Actions = append(p.Actions, acts...)
+		for _, name := range pending {
+			p.PendingSchemas[name] = true
 		}
 	}
 
-	sort.Strings(issues)
-	return issues
+	oldKeys := make([]string, 0, len(oldOps))
+	for key := range oldOps {
+		oldKeys = append(oldKeys, key)
+	}
+	sort.Strings(oldKeys)
+	for _, key := range oldKeys {
+		if _, stillPresent := newOps[key]; !stillPresent {
+			p.addNeedsHuman(
+				"NEEDS_HUMAN: operation %s present in the committed snapshot is absent from the target spec (removal is always a hard fail)", key)
+		}
+	}
+
+	sort.Strings(p.NeedsHuman)
+	return p
 }

--- a/cmd/apisync/operations_test.go
+++ b/cmd/apisync/operations_test.go
@@ -30,6 +30,11 @@ func getOp(responseSchemaRef string) map[string]any {
 }
 
 func TestCheckOperationChanges_NewOperationHardFailsByDefault(t *testing.T) {
+	// No fixture SDK packages exist at all, so the deterministic generator
+	// can never resolve a target package for this route and must fall back
+	// to NEEDS_HUMAN, exactly like the pre-generator behavior.
+	repoRoot := writeFixture(t, map[string]string{"go.mod": "module example.com/fixture\n\ngo 1.21\n"})
+
 	sm := &SpecMap{Types: []TypeMapping{{Spec: "PayoutOut", SDK: []SDKSite{{File: "x", Symbol: "Y"}}}}}
 	oldSpec := specWithPaths(t, map[string]string{"PayoutOut": `{"type":"object","properties":{}}`}, map[string]any{})
 	newSpec := specWithPaths(t, map[string]string{"PayoutOut": `{"type":"object","properties":{}}`}, map[string]any{
@@ -38,13 +43,14 @@ func TestCheckOperationChanges_NewOperationHardFailsByDefault(t *testing.T) {
 		},
 	})
 
-	issues := checkOperationChanges(sm, oldSpec, newSpec)
+	issues := checkOperationChanges(repoRoot, sm, oldSpec, newSpec).NeedsHuman
 	require.True(t, containsString(issues, "GET /v1/instances/{instance_id}/payouts/new-thing"))
 	require.True(t, containsString(issues, "NEEDS_HUMAN"))
 	require.True(t, containsString(issues, "hand-written client wiring"))
 }
 
 func TestCheckOperationChanges_NewOperationInAnIgnoredFamilyIsNotBlocking(t *testing.T) {
+	repoRoot := writeFixture(t, map[string]string{"go.mod": "module example.com/fixture\n\ngo 1.21\n"})
 	sm := &SpecMap{}
 	sm.Ignore.Schemas = []IgnoreEntry{{Schema: "Rfi", Reason: "not modeled"}}
 
@@ -69,8 +75,8 @@ func TestCheckOperationChanges_NewOperationInAnIgnoredFamilyIsNotBlocking(t *tes
 				"/v1/instances/{instance_id}/rfi/new-endpoint": map[string]any{"get": tt.op},
 			})
 
-			issues := checkOperationChanges(sm, oldSpec, newSpec)
-			require.Empty(t, issues, "a new operation reachable only through an already-ignored schema/tag must not block the pipeline")
+			plan := checkOperationChanges(repoRoot, sm, oldSpec, newSpec)
+			require.Empty(t, plan.NeedsHuman, "a new operation reachable only through an already-ignored schema/tag must not block the pipeline")
 		})
 	}
 }
@@ -80,6 +86,7 @@ func TestCheckOperationChanges_TagPrefixAloneIsNotEnoughToExempt(t *testing.T) {
 	// UploadAnalyzeIn/UploadAnalyzeOut; a tag "Upload" must not exempt an
 	// operation by loosely prefix-matching the ignored name, since that
 	// would also wrongly exempt a genuinely new Upload-family operation.
+	repoRoot := writeFixture(t, map[string]string{"go.mod": "module example.com/fixture\n\ngo 1.21\n"})
 	sm := &SpecMap{}
 	sm.Ignore.Schemas = []IgnoreEntry{{Schema: "UploadAnalyzeOut", Reason: "not modeled"}}
 
@@ -94,29 +101,32 @@ func TestCheckOperationChanges_TagPrefixAloneIsNotEnoughToExempt(t *testing.T) {
 		},
 	})
 
-	issues := checkOperationChanges(sm, oldSpec, newSpec)
+	issues := checkOperationChanges(repoRoot, sm, oldSpec, newSpec).NeedsHuman
 	require.True(t, containsString(issues, "POST /v1/upload/new-variant"), "referencing a MAPPED schema (UploadOut) must still hard-fail even though the tag loosely resembles an ignored family name")
 }
 
 func TestCheckOperationChanges_RemovedOperationIsAlwaysNeedsHuman(t *testing.T) {
+	repoRoot := writeFixture(t, map[string]string{"go.mod": "module example.com/fixture\n\ngo 1.21\n"})
 	sm := &SpecMap{}
 	oldSpec := specWithPaths(t, map[string]string{}, map[string]any{
 		"/v1/instances/{instance_id}/widgets": map[string]any{"get": map[string]any{"responses": map[string]any{"200": map[string]any{}}}},
 	})
 	newSpec := specWithPaths(t, map[string]string{}, map[string]any{})
 
-	issues := checkOperationChanges(sm, oldSpec, newSpec)
+	issues := checkOperationChanges(repoRoot, sm, oldSpec, newSpec).NeedsHuman
 	require.True(t, containsString(issues, "GET /v1/instances/{instance_id}/widgets"))
 	require.True(t, containsString(issues, "removal is always a hard fail"))
 }
 
 func TestCheckOperationChanges_NoChangeIsClean(t *testing.T) {
+	repoRoot := writeFixture(t, map[string]string{"go.mod": "module example.com/fixture\n\ngo 1.21\n"})
 	sm := &SpecMap{}
 	spec := specWithPaths(t, map[string]string{}, map[string]any{
 		"/v1/widgets": map[string]any{"get": map[string]any{"responses": map[string]any{"200": map[string]any{}}}},
 	})
-	issues := checkOperationChanges(sm, spec, spec)
-	require.Empty(t, issues)
+	plan := checkOperationChanges(repoRoot, sm, spec, spec)
+	require.Empty(t, plan.NeedsHuman)
+	require.Empty(t, plan.Actions)
 }
 
 func TestCheckUnclassifiedSchemas_NewSchemaAbsentFromCommittedSnapshotIsNeedsHuman(t *testing.T) {
@@ -138,7 +148,7 @@ func TestCheckUnclassifiedSchemas_NewSchemaAbsentFromCommittedSnapshotIsNeedsHum
 		"/v1/new":     map[string]any{"get": getOp("BrandNewThing")},
 	})
 
-	issues := checkUnclassifiedSchemas(sm, newSpec)
+	issues := checkUnclassifiedSchemas(sm, newSpec, nil)
 	require.True(t, containsString(issues, "BrandNewThing"))
 	require.True(t, containsString(issues, "NEEDS_HUMAN"))
 }

--- a/cmd/apisync/opinsert.go
+++ b/cmd/apisync/opinsert.go
@@ -1,0 +1,866 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// pkgTarget is one resolved landing spot for a brand-new operation: the
+// existing SDK package directory it belongs to (found mechanically, by
+// path-literal prefix, never a hand-maintained tag/dir alias table) plus
+// the path segments left over after that package's own resource root.
+type pkgTarget struct {
+	Dir      string   // package directory, e.g. "partnerfees"
+	Package  string   // Go package name declared in that directory
+	TailSegs []string // original ({param}-form) path segments after the matched root
+}
+
+// sdkPathLiteralsByDir is pathcoverage.go's sdkPathLiterals, bucketed by
+// top-level package directory instead of flattened -- the signal
+// resolveTarget needs to decide *which* existing package a brand-new
+// operation's path belongs to.
+func sdkPathLiteralsByDir(repoRoot string) (map[string]map[string]bool, error) {
+	out := map[string]map[string]bool{}
+	err := filepath.WalkDir(repoRoot, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(repoRoot, p)
+		if relErr != nil {
+			return relErr
+		}
+		top := strings.SplitN(rel, string(filepath.Separator), 2)[0]
+		if d.IsDir() {
+			if rel != "." && skipDirsCoverage[top] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if top == rel {
+			return nil // a file directly at repo root is never a package dir we resolve against
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, p, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			val, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			if idx := strings.Index(val, "?"); idx != -1 {
+				val = val[:idx]
+			}
+			if pathLiteralRE.MatchString(val) {
+				if out[top] == nil {
+					out[top] = map[string]bool{}
+				}
+				out[top][val] = true
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// resolveTarget finds the one existing SDK package directory whose own
+// path literals share the longest leading run of segments with specPath
+// (comparing "{param}" spec segments against that package's "%s"
+// placeholders positionally, e.g. "/instances/%s/partner-fees" against
+// "/instances/{instance_id}/partner-fees/{id}"). Zero or ambiguous matches
+// are both refused -- a patcher must never guess which package a new
+// route belongs to.
+func resolveTarget(repoRoot, specPath string) (*pkgTarget, error) {
+	segs := strings.Split(strings.TrimPrefix(specPath, "/"), "/")
+	if len(segs) > 0 && segs[0] == "v1" {
+		segs = segs[1:]
+	}
+	norm := make([]string, len(segs))
+	for i, s := range segs {
+		if strings.HasPrefix(s, "{") {
+			norm[i] = "%s"
+		} else {
+			norm[i] = s
+		}
+	}
+
+	byDir, err := sdkPathLiteralsByDir(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("scanning SDK path literals: %w", err)
+	}
+
+	// "instances/%s/..." is a fixed, universal prefix shared by nearly
+	// every route (the instance_id every operation is scoped by); it
+	// carries no resource-identifying signal at all, so it is stripped
+	// before matching and re-added (as a fixed +2 offset) afterward.
+	prefixLen := 0
+	if len(norm) >= 2 && norm[0] == "instances" && norm[1] == "%s" {
+		prefixLen = 2
+	}
+	normRest := norm[prefixLen:]
+
+	bestDir, bestLen := "", 0
+	ambiguous := false
+	for dir, lits := range byDir {
+		for lit := range lits {
+			litSegs := strings.Split(strings.Trim(lit, "/"), "/")
+			litPrefixLen := 0
+			if len(litSegs) >= 2 && litSegs[0] == "instances" && litSegs[1] == "%s" {
+				litPrefixLen = 2
+			}
+			litRest := litSegs[litPrefixLen:]
+
+			// Cap the match at the literal's own resource root -- its first
+			// "%s" placeholder -- so a sibling id-form route (e.g. an
+			// existing Delete's ".../partner-fees/%s") never gets credit
+			// for matching all the way through a *different* id value too,
+			// which would wrongly swallow the new route's own trailing
+			// {id} into the "root" and leave no tail to name a method from.
+			litRootLen := 0
+			for _, s := range litRest {
+				if s == "%s" {
+					break
+				}
+				litRootLen++
+			}
+			n := 0
+			for n < len(normRest) && n < litRootLen && normRest[n] == litRest[n] {
+				n++
+			}
+			if n == 0 {
+				continue
+			}
+			switch {
+			case n > bestLen:
+				bestLen, bestDir, ambiguous = n, dir, false
+			case n == bestLen && dir != bestDir:
+				ambiguous = true
+			}
+		}
+	}
+	if bestLen == 0 {
+		return nil, fmt.Errorf("no existing SDK package has a path literal sharing a leading path segment with %q; a human must add the new package/client wiring", specPath)
+	}
+	if ambiguous {
+		return nil, fmt.Errorf("path %q matches more than one existing SDK package's path prefix equally well; ambiguous, a human must decide", specPath)
+	}
+
+	pkgName, err := packageNameOfDir(repoRoot, bestDir)
+	if err != nil {
+		return nil, err
+	}
+	return &pkgTarget{Dir: bestDir, Package: pkgName, TailSegs: segs[prefixLen+bestLen:]}, nil
+}
+
+func packageNameOfDir(repoRoot, dir string) (string, error) {
+	absDir := filepath.Join(repoRoot, dir)
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, filepath.Join(absDir, name), nil, parser.PackageClauseOnly)
+		if err != nil {
+			continue
+		}
+		return f.Name.Name, nil
+	}
+	return "", fmt.Errorf("%s: no non-test .go file found to determine the package name", dir)
+}
+
+// existingMethodNames returns every method already declared on dir's
+// Client, so a generated name never collides with one already there.
+func existingMethodNames(repoRoot, dir string) (map[string]bool, error) {
+	out := map[string]bool{}
+	path := filepath.Join(repoRoot, dir, "client.go")
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s/client.go: %w", dir, err)
+	}
+	for _, decl := range astFile.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		out[fn.Name.Name] = true
+	}
+	return out, nil
+}
+
+// allStructShapesInDir is goast.go's findStructShape generalized to every
+// struct declared anywhere in dir (any non-test .go file), used to look
+// for an existing struct a newly synthesized one can be deduplicated
+// against (see findDedupStruct) instead of emitting a redundant type.
+func allStructShapesInDir(repoRoot, dir string) ([]*StructShape, error) {
+	absDir := filepath.Join(repoRoot, dir)
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, err
+	}
+	var out []*StructShape
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		rel := dir + "/" + name
+		fset := token.NewFileSet()
+		astFile, err := parser.ParseFile(fset, filepath.Join(repoRoot, rel), nil, parser.ParseComments)
+		if err != nil {
+			return nil, err
+		}
+		for _, decl := range astFile.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok || structType.Fields == nil {
+					continue
+				}
+				shape := &StructShape{
+					File:             rel,
+					Symbol:           typeSpec.Name.Name,
+					ClosingBraceLine: fset.Position(structType.Fields.Closing).Line,
+					Indent:           "\t",
+				}
+				for _, f := range structType.Fields.List {
+					if line := fset.Position(f.End()).Line; line > shape.LastFieldLine {
+						shape.LastFieldLine = line
+					}
+					if len(f.Names) == 0 || f.Tag == nil {
+						continue
+					}
+					tagVal, err := strconv.Unquote(f.Tag.Value)
+					if err != nil {
+						continue
+					}
+					jsonName, omitempty := parseJSONTag(tagVal)
+					if jsonName == "" || jsonName == "-" {
+						continue
+					}
+					_, isPointer := f.Type.(*ast.StarExpr)
+					shape.Fields = append(shape.Fields, FieldShape{
+						GoName:    f.Names[0].Name,
+						JSONName:  jsonName,
+						Omitempty: omitempty,
+						Pointer:   isPointer,
+						GoType:    typeExprString(f.Type),
+					})
+				}
+				if shape.LastFieldLine == 0 {
+					shape.LastFieldLine = shape.ClosingBraceLine - 1
+				}
+				out = append(out, shape)
+			}
+		}
+	}
+	return out, nil
+}
+
+func lastLineOf(repoRoot, file string) (int, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, file))
+	if err != nil {
+		return 0, err
+	}
+	// Mirrors applyInsertions' own strings.Split(data, "\n"); using the same
+	// split keeps "insert after the last line" exactly equivalent to append.
+	return len(strings.Split(string(data), "\n")), nil
+}
+
+// jsonArrayOpenLine returns the 1-indexed line of `"key": [` in a
+// .api-sync/*.json config file, so a new entry can be spliced in as the
+// array's new first element via the same insertion mechanism goast.go
+// already uses for Go source -- these config files are hand-formatted
+// JSON, not machine re-marshaled, so a line splice (not a JSON re-encode)
+// is the only way to add an entry without reordering/reformatting
+// everything else in the file.
+func jsonArrayOpenLine(repoRoot, file, key string) (int, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, file))
+	if err != nil {
+		return 0, err
+	}
+	pattern := fmt.Sprintf(`"%s": [`, key)
+	for i, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, pattern) {
+			return i + 1, nil
+		}
+	}
+	return 0, fmt.Errorf("%s: %q array not found", file, key)
+}
+
+func renderTypeMappingJSON(tm TypeMapping) string {
+	return fmt.Sprintf("    {\n      \"spec\": %q,\n      \"sdk\": [{ \"file\": %q, \"symbol\": %q }]\n    },",
+		tm.Spec, tm.SDK[0].File, tm.SDK[0].Symbol)
+}
+
+// synthField is one property of a struct this generator is about to emit.
+type synthField struct {
+	JSONName string
+	GoName   string
+	GoType   string // "string", "[]string", never a pointer -- callers decide pointer-vs-bare per field
+	Required bool
+}
+
+// flatGoType maps a JSON Schema property definition to a Go scalar or
+// array-of-scalar type. ok is false for anything else (enum, object,
+// union, array of non-scalar) -- exactly the shapes this deterministic
+// generator refuses to guess at, same posture as reconcile.go's
+// scalarGoType for hand-added fields on already-mapped types.
+func flatGoType(def map[string]any) (goType string, ok bool) {
+	if def == nil {
+		return "", false
+	}
+	if _, hasEnum := def["enum"]; hasEnum {
+		return "", false
+	}
+	bases := baseTypes(def)
+	if len(bases) == 1 && bases[0] == "array" {
+		items, _ := def["items"].(map[string]any)
+		if items == nil {
+			return "", false
+		}
+		if _, hasEnum := items["enum"]; hasEnum {
+			return "", false
+		}
+		itemType, ok := scalarGoType(items)
+		if !ok {
+			return "", false
+		}
+		return "[]" + itemType, true
+	}
+	return scalarGoType(def)
+}
+
+// flatSchemaFields returns every property of schema as a synthField, or
+// ok=false the moment any single property isn't flatGoType-expressible --
+// a schema is either entirely synthesizable or not synthesized at all,
+// never partially modeled.
+func flatSchemaFields(schema map[string]any) ([]synthField, bool) {
+	props := properties(schema)
+	req := requiredSet(schema)
+	names := make([]string, 0, len(props))
+	for n := range props {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	fields := make([]synthField, 0, len(names))
+	for _, n := range names {
+		def, _ := props[n].(map[string]any)
+		gt, ok := flatGoType(def)
+		if !ok {
+			return nil, false
+		}
+		fields = append(fields, synthField{JSONName: n, GoName: fieldGoName(n), GoType: gt, Required: req[n]})
+	}
+	return fields, true
+}
+
+// fieldGoName is pascalCase specialized for struct field names: an "id"
+// segment (whole word, any position, e.g. "id" or "instance_id") is
+// capitalized "ID" throughout, matching this repo's existing hand-written
+// fields (PartnerFee.ID, VirtualAccountOut's InstanceID, etc.) rather than
+// pascalCase's generic "Id".
+func fieldGoName(jsonName string) string {
+	var b strings.Builder
+	for _, part := range strings.FieldsFunc(jsonName, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if strings.EqualFold(part, "id") {
+			b.WriteString("ID")
+			continue
+		}
+		b.WriteString(pascalCase(part))
+	}
+	return b.String()
+}
+
+func renderStruct(name string, fields []synthField) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\ntype %s struct {\n", name)
+	for _, f := range fields {
+		isArray := strings.HasPrefix(f.GoType, "[]")
+		switch {
+		case f.Required || isArray:
+			fmt.Fprintf(&b, "\t%s %s `json:\"%s%s\"`\n", f.GoName, f.GoType, f.JSONName, omitemptySuffix(!f.Required))
+		default:
+			fmt.Fprintf(&b, "\t%s *%s `json:\"%s,omitempty\"`\n", f.GoName, f.GoType, f.JSONName)
+		}
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func omitemptySuffix(optional bool) string {
+	if optional {
+		return ",omitempty"
+	}
+	return ""
+}
+
+// canonicalSig is the (json name, base Go type) signature used to detect
+// that two structs describe the same wire shape, ignoring pointer style.
+func canonicalSig(jsonName, goType string) string {
+	return jsonName + ":" + strings.TrimPrefix(goType, "*")
+}
+
+// findDedupStruct looks for an existing struct in dir whose field set is
+// wire-identical to the one about to be synthesized, so a repeated inline
+// shape (e.g. the same flat object reused as several sibling operations'
+// response) reuses one type instead of each operation minting its own.
+func findDedupStruct(repoRoot, dir string, fields []synthField) (string, bool) {
+	want := map[string]bool{}
+	for _, f := range fields {
+		want[canonicalSig(f.JSONName, f.GoType)] = true
+	}
+	shapes, err := allStructShapesInDir(repoRoot, dir)
+	if err != nil {
+		return "", false
+	}
+	for _, s := range shapes {
+		if len(s.Fields) != len(fields) {
+			continue
+		}
+		got := map[string]bool{}
+		for _, f := range s.Fields {
+			got[canonicalSig(f.JSONName, f.GoType)] = true
+		}
+		if len(got) != len(want) {
+			continue
+		}
+		match := true
+		for k := range want {
+			if !got[k] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return s.Symbol, true
+		}
+	}
+	return "", false
+}
+
+// bodySpec is the resolved shape of one operation's request or response
+// body: the Go type to use (bare, never pointer -- callers pointerize
+// object types, leave slices bare), plus optionally a brand-new struct's
+// source text and/or a spec-map.json registration when the body's named
+// schema had no existing SDK mapping.
+type bodySpec struct {
+	Kind       string // "none" or "type"
+	GoType     string
+	NewStruct  string
+	NewMapping *TypeMapping
+}
+
+// resolveBody classifies one requestBody/response content map. Only
+// application/json is ever expressible; everything else (multipart,
+// binary, or any other media type) is refused with a precise reason.
+func resolveBody(repoRoot string, sm *SpecMap, spec *specDoc, dir, methodName, roleSuffix string, content map[string]any) (*bodySpec, string) {
+	if len(content) == 0 {
+		return &bodySpec{Kind: "none"}, ""
+	}
+	appJSON, ok := content["application/json"].(map[string]any)
+	if !ok || len(content) != 1 {
+		var kinds []string
+		for k := range content {
+			kinds = append(kinds, k)
+		}
+		sort.Strings(kinds)
+		return nil, fmt.Sprintf("non-JSON content type(s) %v (multipart/binary/streaming bodies are not expressible by this generator)", kinds)
+	}
+	schema, _ := appJSON["schema"].(map[string]any)
+	if schema == nil {
+		return nil, "application/json content has no schema"
+	}
+
+	if ref, ok := schema["$ref"].(string); ok {
+		name := strings.TrimPrefix(ref, "#/components/schemas/")
+		return resolveNamedSchema(repoRoot, sm, spec, dir, name, false)
+	}
+	if t, _ := schema["type"].(string); t == "array" {
+		items, _ := schema["items"].(map[string]any)
+		if items == nil {
+			return nil, "array body has no items schema"
+		}
+		if ref, ok := items["$ref"].(string); ok {
+			name := strings.TrimPrefix(ref, "#/components/schemas/")
+			return resolveNamedSchema(repoRoot, sm, spec, dir, name, true)
+		}
+		if gt, ok := flatGoType(schema); ok {
+			return &bodySpec{Kind: "type", GoType: gt}, ""
+		}
+		return nil, "array body items are neither a $ref to a component schema nor a flat scalar shape"
+	}
+
+	fields, ok := flatSchemaFields(schema)
+	if !ok {
+		return nil, "inline body schema has a non-scalar property (nested object, union, or enum-constrained field); needs a human-designed type"
+	}
+	structName := methodName + roleSuffix
+	if reuse, ok := findDedupStruct(repoRoot, dir, fields); ok {
+		return &bodySpec{Kind: "type", GoType: reuse}, ""
+	}
+	return &bodySpec{Kind: "type", GoType: structName, NewStruct: renderStruct(structName, fields)}, ""
+}
+
+// resolveNamedSchema handles a $ref (directly, or as an array's items) to
+// a component schema. An already-mapped schema is reused as-is, but only
+// when every one of its SDK sites already lives in the target package --
+// cross-package type reuse would need import management this generator
+// deliberately does not attempt. An unmapped schema is synthesized (same
+// flat-shape-only rule as inline bodies) and queued for spec-map.json
+// registration, so future drift on it is patchable by ordinary reconcile,
+// not by a second round of operation-insert.
+func resolveNamedSchema(repoRoot string, sm *SpecMap, spec *specDoc, dir, name string, isArray bool) (*bodySpec, string) {
+	for _, tm := range sm.Types {
+		if tm.Spec != name {
+			continue
+		}
+		if len(tm.SDK) == 0 {
+			return nil, fmt.Sprintf("schema %q is mapped in spec-map.json with no SDK site", name)
+		}
+		for _, site := range tm.SDK {
+			if siteDir(site.File) != dir {
+				return nil, fmt.Sprintf("schema %q is already mapped to %s (%s), outside the target package %q; cross-package type reuse is not supported by this generator", name, site.Symbol, site.File, dir)
+			}
+		}
+		symbol := tm.SDK[0].Symbol
+		gt := symbol
+		if isArray {
+			gt = "[]" + symbol
+		}
+		return &bodySpec{Kind: "type", GoType: gt}, ""
+	}
+
+	schemaDef, _, ok := spec.schema(name)
+	if !ok {
+		return nil, fmt.Sprintf("schema %q referenced by $ref could not be resolved in the target spec", name)
+	}
+	fields, ok := flatSchemaFields(schemaDef)
+	if !ok {
+		return nil, fmt.Sprintf("schema %q has a non-flat shape (nested object, union, or enum-constrained property); this generator only synthesizes brand-new named schemas that are entirely flat scalar/array-of-scalar", name)
+	}
+
+	structName := pascalCase(name)
+	var newStruct string
+	typeName := structName
+	if reuse, ok := findDedupStruct(repoRoot, dir, fields); ok {
+		typeName = reuse
+	} else {
+		newStruct = renderStruct(structName, fields)
+	}
+	gt := typeName
+	if isArray {
+		gt = "[]" + typeName
+	}
+	mapping := &TypeMapping{Spec: name, SDK: []SDKSite{{File: dir + "/client.go", Symbol: typeName}}}
+	return &bodySpec{Kind: "type", GoType: gt, NewStruct: newStruct, NewMapping: mapping}, ""
+}
+
+func siteDir(file string) string {
+	if i := strings.LastIndex(file, "/"); i >= 0 {
+		return file[:i]
+	}
+	return ""
+}
+
+func asPtr(t string) string {
+	if strings.HasPrefix(t, "[]") {
+		return t
+	}
+	return "*" + t
+}
+
+// successResponseContent picks the operation's primary 2xx response body
+// (preferring 200, then the lowest remaining 2xx code), returning ok=false
+// when there is no response body to model (e.g. 204, or no 2xx at all).
+func successResponseContent(op map[string]any) (map[string]any, bool) {
+	responses, _ := op["responses"].(map[string]any)
+	if responses == nil {
+		return nil, false
+	}
+	var codes []string
+	for c := range responses {
+		if strings.HasPrefix(c, "2") {
+			codes = append(codes, c)
+		}
+	}
+	sort.Strings(codes)
+	for _, c := range codes {
+		r, _ := responses[c].(map[string]any)
+		if content, ok := r["content"].(map[string]any); ok && len(content) > 0 {
+			return content, true
+		}
+	}
+	return nil, false
+}
+
+// deriveMethodName mechanically names the generated method from the HTTP
+// verb and the path segments left over after the matched resource root,
+// mirroring this repo's existing hand-written naming (List/Get/Create/
+// Update/Delete for a bare resource root, Get<Tail>/<Tail>/Update<Tail>/
+// Delete<Tail> for a literal sub-route such as ".../balance" or
+// ".../sign-message").
+func deriveMethodName(httpMethod string, tailSegs []string) string {
+	var suffix strings.Builder
+	hasParam := false
+	for _, seg := range tailSegs {
+		if strings.HasPrefix(seg, "{") {
+			hasParam = true
+			continue
+		}
+		suffix.WriteString(pascalCase(seg))
+	}
+	tail := suffix.String()
+
+	switch httpMethod {
+	case "GET":
+		if tail != "" {
+			return "Get" + tail
+		}
+		if hasParam {
+			return "Get"
+		}
+		return "List"
+	case "POST":
+		if tail != "" {
+			return tail
+		}
+		return "Create"
+	case "PUT", "PATCH":
+		if tail != "" {
+			return "Update" + tail
+		}
+		return "Update"
+	case "DELETE":
+		if tail != "" {
+			return "Delete" + tail
+		}
+		return "Delete"
+	}
+	return ""
+}
+
+// camelParam converts a snake_case path parameter name into this repo's Go
+// parameter-naming convention: lowerCamel, with a standalone or trailing
+// "id" segment capitalized to "ID" (matching existing hand-written
+// signatures like "customerID, id string").
+func camelParam(name string) string {
+	parts := strings.Split(name, "_")
+	var b strings.Builder
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		switch {
+		case i == 0 && strings.EqualFold(p, "id"):
+			b.WriteString("id")
+		case strings.EqualFold(p, "id"):
+			b.WriteString("ID")
+		case i == 0:
+			b.WriteString(strings.ToLower(p[:1]) + strings.ToLower(p[1:]))
+		default:
+			b.WriteString(strings.ToUpper(p[:1]) + strings.ToLower(p[1:]))
+		}
+	}
+	return b.String()
+}
+
+// buildPathTemplate turns a spec path (with "{param}" segments) into this
+// SDK's fmt.Sprintf style ("%s" placeholders) plus the ordered Sprintf
+// arguments -- "{instance_id}" always resolves to "c.instanceID" (this
+// SDK's existing convention, never a function parameter), every other
+// param consumes the next entry of pathArgs in path order.
+func buildPathTemplate(specPath string, pathArgs []string) (string, []string) {
+	trimmed := strings.TrimPrefix(specPath, "/v1")
+	var fmtBuf strings.Builder
+	var args []string
+	pi := 0
+	for i := 0; i < len(trimmed); {
+		if trimmed[i] == '{' {
+			j := strings.IndexByte(trimmed[i:], '}')
+			name := trimmed[i+1 : i+j]
+			fmtBuf.WriteString("%s")
+			if name == "instance_id" {
+				args = append(args, "c.instanceID")
+			} else {
+				args = append(args, pathArgs[pi])
+				pi++
+			}
+			i += j + 1
+			continue
+		}
+		fmtBuf.WriteByte(trimmed[i])
+		i++
+	}
+	return fmtBuf.String(), args
+}
+
+func renderMethod(methodName, httpMethod, specPath string, pathArgs []string, req, resp *bodySpec) string {
+	pathFmt, sprintfArgs := buildPathTemplate(specPath, pathArgs)
+
+	sigParams := []string{"ctx context.Context"}
+	for _, a := range pathArgs {
+		sigParams = append(sigParams, a+" string")
+	}
+	bodyArg := "nil"
+	if req.Kind != "none" {
+		sigParams = append(sigParams, "params "+asPtr(req.GoType))
+		bodyArg = "params"
+	}
+
+	var retType, callLine string
+	if resp.Kind == "none" {
+		retType = "error"
+		callLine = fmt.Sprintf("_, err := request.Do[struct{}](c.cfg, ctx, %q, path, %s)\n\treturn err", httpMethod, bodyArg)
+	} else {
+		rt := asPtr(resp.GoType)
+		retType = fmt.Sprintf("(%s, error)", rt)
+		callLine = fmt.Sprintf("return request.Do[%s](c.cfg, ctx, %q, path, %s)", rt, httpMethod, bodyArg)
+	}
+
+	return fmt.Sprintf(`
+// %s corresponds to %s %s (generated by cmd/apisync's operation-insert).
+func (c *Client) %s(%s) %s {
+	path := fmt.Sprintf(%q, %s)
+	%s
+}
+`, methodName, httpMethod, specPath, methodName, strings.Join(sigParams, ", "), retType, pathFmt, strings.Join(sprintfArgs, ", "), callLine)
+}
+
+// classifyAndPlanOperation is checkOperationChanges' STANDARD/NON-STANDARD
+// decision for exactly one brand-new operation. On success it returns the
+// full set of actions to apply (method + any brand-new structs + any
+// spec-map.json registrations) and the spec schema names those
+// registrations cover (so the caller can keep checkUnclassifiedSchemas
+// from re-flagging a schema this same run is about to map). On failure it
+// returns a precise NON-STANDARD reason and no actions.
+func classifyAndPlanOperation(repoRoot string, sm *SpecMap, spec *specDoc, entry operationEntry) (acts []action, pendingSchemas []string, reason string) {
+	target, err := resolveTarget(repoRoot, entry.Path)
+	if err != nil {
+		return nil, nil, err.Error()
+	}
+	methods, err := existingMethodNames(repoRoot, target.Dir)
+	if err != nil {
+		return nil, nil, fmt.Sprintf("could not read %s/client.go: %v", target.Dir, err)
+	}
+
+	methodName := deriveMethodName(entry.Method, target.TailSegs)
+	if methodName == "" {
+		return nil, nil, fmt.Sprintf("could not derive a deterministic method name for %s (unsupported verb)", entry.Method)
+	}
+	if methods[methodName] {
+		return nil, nil, fmt.Sprintf("derived method name %q already exists on %s.Client; a human must pick a non-colliding name", methodName, target.Package)
+	}
+
+	req := &bodySpec{Kind: "none"}
+	if rb, ok := entry.Op["requestBody"].(map[string]any); ok {
+		content, _ := rb["content"].(map[string]any)
+		b, why := resolveBody(repoRoot, sm, spec, target.Dir, methodName, "Params", content)
+		if why != "" {
+			return nil, nil, "request body: " + why
+		}
+		req = b
+	}
+
+	// DELETE always discards the response body in this SDK's existing
+	// convention (see e.g. partnerfees.Delete), regardless of what the
+	// spec's DELETE response schema is.
+	resp := &bodySpec{Kind: "none"}
+	if entry.Method != "DELETE" {
+		if content, ok := successResponseContent(entry.Op); ok {
+			b, why := resolveBody(repoRoot, sm, spec, target.Dir, methodName, "Response", content)
+			if why != "" {
+				return nil, nil, "response body: " + why
+			}
+			resp = b
+		}
+	}
+
+	var pathArgs []string
+	for _, seg := range strings.Split(strings.TrimPrefix(entry.Path, "/v1"), "/") {
+		if !strings.HasPrefix(seg, "{") {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(seg, "{"), "}")
+		if name == "instance_id" {
+			continue
+		}
+		pathArgs = append(pathArgs, camelParam(name))
+	}
+
+	methodText := renderMethod(methodName, entry.Method, entry.Path, pathArgs, req, resp)
+
+	var pieces []string
+	if req.NewStruct != "" {
+		pieces = append(pieces, req.NewStruct)
+	}
+	if resp.NewStruct != "" && resp.NewStruct != req.NewStruct {
+		pieces = append(pieces, resp.NewStruct)
+	}
+	pieces = append(pieces, methodText)
+
+	clientFile := target.Dir + "/client.go"
+	lastLine, err := lastLineOf(repoRoot, clientFile)
+	if err != nil {
+		return nil, nil, fmt.Sprintf("could not read %s: %v", clientFile, err)
+	}
+
+	acts = append(acts, action{
+		description: fmt.Sprintf("operation-insert: %s %s -> %s.%s (%s)", entry.Method, entry.Path, target.Package, methodName, clientFile),
+		insert:      insertion{File: clientFile, Line: lastLine, Text: strings.Join(pieces, "\n")},
+		bump:        "minor",
+	})
+
+	for _, m := range []*TypeMapping{req.NewMapping, resp.NewMapping} {
+		if m == nil {
+			continue
+		}
+		line, err := jsonArrayOpenLine(repoRoot, ".api-sync/spec-map.json", "types")
+		if err != nil {
+			return nil, nil, fmt.Sprintf("could not locate spec-map.json types[] array: %v", err)
+		}
+		acts = append(acts, action{
+			description: fmt.Sprintf("operation-insert: spec-map.json: register schema %s -> %s.%s", m.Spec, target.Package, m.SDK[0].Symbol),
+			insert:      insertion{File: ".api-sync/spec-map.json", Line: line, Text: renderTypeMappingJSON(*m)},
+			bump:        "minor",
+		})
+		pendingSchemas = append(pendingSchemas, m.Spec)
+	}
+
+	return acts, pendingSchemas, ""
+}

--- a/cmd/apisync/opinsert_test.go
+++ b/cmd/apisync/opinsert_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// gadgetsFixture builds a tiny synthetic SDK package ("gadgets") with one
+// existing List method, for classifier unit tests that don't need the
+// full real repo.
+func gadgetsFixture(t *testing.T) string {
+	t.Helper()
+	return writeFixture(t, map[string]string{
+		"go.mod":                  "module example.com/fixture\n\ngo 1.21\n",
+		".api-sync/spec-map.json": "{\n  \"enums\": [],\n  \"types\": [\n    { \"spec\": \"Placeholder\", \"sdk\": [{ \"file\": \"gadgets/client.go\", \"symbol\": \"Gadget\" }] }\n  ]\n}\n",
+		"gadgets/client.go": `package gadgets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blindpaylabs/blindpay-go/internal/request"
+)
+
+type Client struct {
+	cfg        *request.Config
+	instanceID string
+}
+
+func (c *Client) List(ctx context.Context) ([]Gadget, error) {
+	path := fmt.Sprintf("/instances/%s/gadgets", c.instanceID)
+	return request.Do[[]Gadget](c.cfg, ctx, "GET", path, nil)
+}
+
+type Gadget struct {
+	ID   string ` + "`json:\"id\"`" + `
+	Name string ` + "`json:\"name\"`" + `
+}
+`,
+	})
+}
+
+func gadgetOp(method string, requestBody, response map[string]any) operationEntry {
+	op := map[string]any{"tags": []any{"Gadgets"}}
+	if requestBody != nil {
+		op["requestBody"] = requestBody
+	}
+	if response != nil {
+		op["responses"] = map[string]any{"200": response}
+	} else {
+		op["responses"] = map[string]any{"204": map[string]any{}}
+	}
+	return operationEntry{Method: method, Path: "/v1/instances/{instance_id}/gadgets/{id}/activate", Tags: []string{"Gadgets"}, Op: op}
+}
+
+func jsonContent(schema map[string]any) map[string]any {
+	return map[string]any{"content": map[string]any{"application/json": map[string]any{"schema": schema}}}
+}
+
+func TestClassifyAndPlanOperation_InlineFlatBodyIsStandard(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{})
+
+	op := gadgetOp("POST",
+		jsonContent(map[string]any{"type": "object", "properties": map[string]any{"reason": map[string]any{"type": "string"}}, "required": []any{"reason"}}),
+		map[string]any{"content": map[string]any{"application/json": map[string]any{
+			"schema": map[string]any{"type": "object", "properties": map[string]any{"ok": map[string]any{"type": "boolean"}}, "required": []any{"ok"}},
+		}}},
+	)
+
+	acts, pending, reason := classifyAndPlanOperation(root, &SpecMap{}, spec, op)
+	require.Empty(t, reason)
+	require.Empty(t, pending) // inline shapes are never spec-map registered
+	require.Len(t, acts, 1)
+	require.Contains(t, acts[0].insert.Text, "func (c *Client) Activate(")
+	require.Contains(t, acts[0].insert.Text, `fmt.Sprintf("/instances/%s/gadgets/%s/activate", c.instanceID, id)`)
+	require.Contains(t, acts[0].insert.Text, `request.Do[*ActivateResponse](c.cfg, ctx, "POST", path, params)`)
+	require.Contains(t, acts[0].insert.Text, "type ActivateParams struct")
+	require.Contains(t, acts[0].insert.Text, "Reason string `json:\"reason\"`")
+	require.Contains(t, acts[0].insert.Text, "type ActivateResponse struct")
+}
+
+func TestClassifyAndPlanOperation_MultipartRequestIsNonStandard(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{})
+
+	op := gadgetOp("POST",
+		map[string]any{"content": map[string]any{"multipart/form-data": map[string]any{
+			"schema": map[string]any{"type": "object", "properties": map[string]any{"file": map[string]any{"type": "string", "format": "binary"}}},
+		}}},
+		nil,
+	)
+
+	acts, _, reason := classifyAndPlanOperation(root, &SpecMap{}, spec, op)
+	require.Nil(t, acts)
+	require.Contains(t, reason, "non-JSON content type")
+	require.Contains(t, reason, "multipart/form-data")
+}
+
+func TestClassifyAndPlanOperation_NonFlatInlineBodyIsNonStandard(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{})
+
+	op := gadgetOp("POST",
+		jsonContent(map[string]any{"type": "object", "properties": map[string]any{
+			"nested": map[string]any{"type": "object", "properties": map[string]any{"x": map[string]any{"type": "string"}}},
+		}}),
+		nil,
+	)
+
+	acts, _, reason := classifyAndPlanOperation(root, &SpecMap{}, spec, op)
+	require.Nil(t, acts)
+	require.Contains(t, reason, "non-scalar property")
+}
+
+func TestClassifyAndPlanOperation_NewNamedRefSchemaIsSynthesizedAndRegistered(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{
+		"GadgetStatusOut": `{"type":"object","properties":{"active":{"type":"boolean"}},"required":["active"]}`,
+	})
+
+	op := gadgetOp("POST", nil, map[string]any{"content": map[string]any{"application/json": map[string]any{
+		"schema": map[string]any{"$ref": "#/components/schemas/GadgetStatusOut"},
+	}}})
+
+	acts, pending, reason := classifyAndPlanOperation(root, &SpecMap{}, spec, op)
+	require.Empty(t, reason)
+	require.Equal(t, []string{"GadgetStatusOut"}, pending)
+	require.Len(t, acts, 2) // method+struct, and the spec-map.json registration
+	require.Contains(t, acts[1].insert.Text, `"spec": "GadgetStatusOut"`)
+	require.Contains(t, acts[1].insert.Text, `"symbol": "GadgetStatusOut"`)
+}
+
+func TestClassifyAndPlanOperation_MappedRefInAnotherPackageIsNonStandard(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{
+		"GadgetStatusOut": `{"type":"object","properties":{"active":{"type":"boolean"}},"required":["active"]}`,
+	})
+	sm := &SpecMap{Types: []TypeMapping{{Spec: "GadgetStatusOut", SDK: []SDKSite{{File: "widgets/client.go", Symbol: "Widget"}}}}}
+
+	op := gadgetOp("POST", nil, map[string]any{"content": map[string]any{"application/json": map[string]any{
+		"schema": map[string]any{"$ref": "#/components/schemas/GadgetStatusOut"},
+	}}})
+
+	acts, _, reason := classifyAndPlanOperation(root, sm, spec, op)
+	require.Nil(t, acts)
+	require.Contains(t, reason, "cross-package type reuse is not supported")
+}
+
+func TestClassifyAndPlanOperation_MethodNameCollisionIsNonStandard(t *testing.T) {
+	root := gadgetsFixture(t)
+	spec := mustSpec(t, map[string]string{})
+
+	op := operationEntry{
+		Method: "GET",
+		Path:   "/v1/instances/{instance_id}/gadgets",
+		Tags:   []string{"Gadgets"},
+		Op:     map[string]any{"tags": []any{"Gadgets"}, "responses": map[string]any{"204": map[string]any{}}},
+	}
+
+	acts, _, reason := classifyAndPlanOperation(root, &SpecMap{}, spec, op)
+	require.Nil(t, acts)
+	require.Contains(t, reason, `"List" already exists`)
+}
+
+func TestDeriveMethodName(t *testing.T) {
+	cases := []struct {
+		method string
+		tail   []string
+		want   string
+	}{
+		{"GET", nil, "List"},
+		{"GET", []string{"{id}"}, "Get"},
+		{"GET", []string{"{id}", "balance"}, "GetBalance"},
+		{"POST", nil, "Create"},
+		{"POST", []string{"{id}", "activate"}, "Activate"},
+		{"PUT", nil, "Update"},
+		{"DELETE", []string{"{id}"}, "Delete"},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, deriveMethodName(tc.method, tc.tail), "%s %v", tc.method, tc.tail)
+	}
+}
+
+func TestCamelParam(t *testing.T) {
+	require.Equal(t, "id", camelParam("id"))
+	require.Equal(t, "customerID", camelParam("customer_id"))
+	require.Equal(t, "userID", camelParam("user_id"))
+	require.Equal(t, "swift", camelParam("swift"))
+}

--- a/cmd/apisync/reachability_test.go
+++ b/cmd/apisync/reachability_test.go
@@ -136,6 +136,6 @@ func TestCheckUnclassifiedSchemas_OrphanSchemaProducesNoWork(t *testing.T) {
 		},
 	})
 
-	issues := checkUnclassifiedSchemas(sm, spec)
+	issues := checkUnclassifiedSchemas(sm, spec, nil)
 	require.Empty(t, issues, "an orphan schema unreachable from any path/webhook/parameter must produce no work")
 }

--- a/cmd/apisync/reconcile.go
+++ b/cmd/apisync/reconcile.go
@@ -18,6 +18,12 @@ type action struct {
 type planResult struct {
 	Actions    []action
 	NeedsHuman []string
+	// PendingSchemas is set only by checkOperationChanges: the spec schema
+	// names its operation-insert actions are about to register in
+	// spec-map.json, so checkUnclassifiedSchemas can treat them as already
+	// classified this same run (the registration hasn't been written to
+	// disk yet -- see reconcileAndMaybeApply).
+	PendingSchemas map[string]bool
 }
 
 func (p *planResult) addNeedsHuman(format string, args ...any) {
@@ -115,7 +121,7 @@ func checkMapValidity(repoRoot string, sm *SpecMap) []string {
 // reachable from any path, webhook, or non-schema component section, even
 // transitively through other schemas' $refs) produces no work at all: see
 // reachableSchemas.
-func checkUnclassifiedSchemas(sm *SpecMap, spec *specDoc) []string {
+func checkUnclassifiedSchemas(sm *SpecMap, spec *specDoc, pending map[string]bool) []string {
 	classified := map[string]bool{}
 	for _, t := range sm.Types {
 		classified[t.Spec] = true
@@ -131,7 +137,7 @@ func checkUnclassifiedSchemas(sm *SpecMap, spec *specDoc) []string {
 		if !reachable[name] {
 			continue // orphan: nothing in the spec's surface can reach it, no work either way
 		}
-		if !classified[name] {
+		if !classified[name] && !pending[name] {
 			issues = append(issues, fmt.Sprintf(
 				"NEEDS_HUMAN: schema %q is not in spec-map.json (neither types[] nor ignore.schemas[]); "+
 					"a human must decide whether to model it or ignore it with a reason", name))

--- a/cmd/apisync/reconcile_test.go
+++ b/cmd/apisync/reconcile_test.go
@@ -472,7 +472,7 @@ func TestCheckUnclassifiedSchemas_FlagsAnUnmappedSchema(t *testing.T) {
 		"/v1/mystery": map[string]any{"get": getOp("Mystery")},
 	})
 
-	issues := checkUnclassifiedSchemas(sm, spec)
+	issues := checkUnclassifiedSchemas(sm, spec, nil)
 	require.True(t, containsString(issues, "Mystery"))
 	require.False(t, containsString(issues, "Widget"))
 	require.False(t, containsString(issues, `"Ignored"`))


### PR DESCRIPTION
## Summary

Extends the apisync patcher (cmd/apisync) so a brand-new spec operation no longer automatically needs a human. `checkOperationChanges` now classifies every operation added relative to the committed snapshot (and not already exempt via an ignored schema/tag):

- **STANDARD** -> fully generated: a client method on the right package, any brand-new request/response structs synthesized from the operation's schema(s), and a `spec-map.json` `types[]` registration for any brand-new named schema (so future drift on it is ordinary reconcile, never a second round of operation-insert).
- **NON-STANDARD** -> `NEEDS_HUMAN` with a precise reason: multipart/binary/streaming or any non-`application/json` content type, no existing package matches the route (or more than one matches equally well), a derived method name collides with one already on the client, or the shape is inexpressible (enum-constrained property, nested object, union, or a $ref to a type already mapped in a *different* package -- cross-package type reuse needs import management this generator deliberately does not attempt).

### Classifier boundary

The package a new operation belongs to is resolved **mechanically**: the longest common path-literal prefix (after stripping the universal `instances/%s/` scoping segment) between the new route and every existing package's own `client.go` path literals -- never a hand-maintained tag/dir alias table. Zero or ambiguous matches are both refused.

A request/response body is only ever synthesized when it is entirely flat: scalar or array-of-scalar properties, no enum, no nested object/union. A `$ref` to an already-mapped schema is reused as-is, but only when every one of its SDK sites already lives in the target package. This mirrors the existing conservative posture in `reconcile.go` (non-scalar new properties on already-mapped types are `NEEDS_HUMAN`, never guessed).

`const Version`'s minor bump on any operation addition was already generic (`operationSetChanged` in `pathcoverage.go`); no separate wiring was needed. `gofmtFile` is now skipped for the new `spec-map.json` insertions, since they aren't Go source (running gofmt on a JSON file errored before this fix).

Known existing gaps (the `/export/*` SDK-only routes, and the `rfi`/`upload/analyze` spec-only routes already absent from the SDK) are untouched: this only fires on operations *added* relative to the committed snapshot, the same basis `checkOperationChanges` already used, so it never sweeps up pre-existing, already-tolerated drift.

### Golden self-test

`cmd/apisync/golden_test.go`, `TestGolden_OperationInsertRegeneratesDeletedMethods`:
- Copies this real repo into a scratch temp dir.
- Deletes `partnerfees.Get` (bare GET) and `partnerfees.Create` (POST with a body) plus the struct/tests that belong solely to them.
- Doctors a throwaway copy of the committed snapshot to also lack those two operations, then `-apply`s against the real, undoctored snapshot as the target spec.
- Asserts: a pending, un-applied operation-insert fails `-check`; the regenerated code matches the originals' route/verb/param types; `go build`, `go vet`, and `go test` all pass on the regenerated tree; a second `-apply` is byte-for-byte identical (idempotent); `-check` is then clean.

`TestGolden_MultipartOperationIsNeedsHuman` proves a synthetic multipart operation on the same package's route still goes to `NEEDS_HUMAN`.

`cmd/apisync/opinsert_test.go` covers the classifier's individual decision points (inline flat body, non-JSON body, non-flat inline body, new named `$ref` schema synthesis + registration, cross-package `$ref` reuse refusal, method-name collision) against a small synthetic fixture package.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -d -s .` clean
- [x] `go run ./cmd/apisync -validate-map`, `-check`, `go run ./cmd/contractcheck` all clean
- [x] `go test -race $(go list ./... | grep -v /examples/)` green, including the new golden/unit tests
- [x] `golangci-lint run ./cmd/apisync/...` clean (one pre-existing, unrelated finding in `fanout_test.go`)

Not release-labeled (infra only, per instructions). Will merge on green CI.

Claude-Session: https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs