### PR TITLE
fix(security): resolve gosec findings in apisync and contractcheck tooling

### DIFF
--- a/cmd/apisync/goast.go
+++ b/cmd/apisync/goast.go
@@ -354,7 +354,7 @@ func applyInsertions(repoRoot string, insertions []insertion) error {
 
 	for file, list := range byFile {
 		path := filepath.Join(repoRoot, file)
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 		if err != nil {
 			return err
 		}
@@ -381,7 +381,7 @@ func applyInsertions(repoRoot string, insertions []insertion) error {
 			lines = out
 		}
 
-		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil { //#nosec G703 -- path joins repoRoot (developer CLI arg) with repo-relative spec-map entries
 			return err
 		}
 	}

--- a/cmd/apisync/main.go
+++ b/cmd/apisync/main.go
@@ -277,7 +277,7 @@ func readSpecFile(repoRoot, path string) ([]byte, map[string]any, error) {
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(repoRoot, path)
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,7 +289,7 @@ func readSpecFile(repoRoot, path string) ([]byte, map[string]any, error) {
 }
 
 func loadSpecMap(repoRoot string) (*SpecMap, error) {
-	data, err := os.ReadFile(filepath.Join(repoRoot, ".api-sync", "spec-map.json"))
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".api-sync", "spec-map.json")) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func loadSpecMap(repoRoot string) (*SpecMap, error) {
 }
 
 func loadUnmodeled(repoRoot string) (*Unmodeled, error) {
-	data, err := os.ReadFile(filepath.Join(repoRoot, ".api-sync", "unmodeled.json"))
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".api-sync", "unmodeled.json")) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func loadUnmodeled(repoRoot string) (*Unmodeled, error) {
 }
 
 func gofmtFile(path string) error {
-	cmd := exec.Command("gofmt", "-w", path)
+	cmd := exec.Command("gofmt", "-w", path) //#nosec G204 -- fixed binary gofmt, path is a repo file this tool just wrote
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %w", string(out), err)

--- a/cmd/apisync/opinsert.go
+++ b/cmd/apisync/opinsert.go
@@ -290,7 +290,7 @@ func allStructShapesInDir(repoRoot, dir string) ([]*StructShape, error) {
 }
 
 func lastLineOf(repoRoot, file string) (int, error) {
-	data, err := os.ReadFile(filepath.Join(repoRoot, file))
+	data, err := os.ReadFile(filepath.Join(repoRoot, file)) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return 0, err
 	}
@@ -307,7 +307,7 @@ func lastLineOf(repoRoot, file string) (int, error) {
 // is the only way to add an entry without reordering/reformatting
 // everything else in the file.
 func jsonArrayOpenLine(repoRoot, file, key string) (int, error) {
-	data, err := os.ReadFile(filepath.Join(repoRoot, file))
+	data, err := os.ReadFile(filepath.Join(repoRoot, file)) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/apisync/report.go
+++ b/cmd/apisync/report.go
@@ -51,5 +51,5 @@ func writeReport(path string, r Report) error {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }

--- a/cmd/apisync/snapshot.go
+++ b/cmd/apisync/snapshot.go
@@ -13,5 +13,5 @@ import (
 // stop matching the bytes blindpay-v2 actually ships as spec-current.json).
 func refreshSnapshot(repoRoot string, specBytes []byte) error {
 	path := filepath.Join(repoRoot, ".api-sync", "spec-snapshot.json")
-	return os.WriteFile(path, specBytes, 0o644)
+	return os.WriteFile(path, specBytes, 0o600)
 }

--- a/cmd/apisync/version.go
+++ b/cmd/apisync/version.go
@@ -16,7 +16,7 @@ var versionLineRE = regexp.MustCompile(`const Version = "(\d+)\.(\d+)\.(\d+)"`)
 // `grep -oP 'const Version = "\K[^"]+'` expects.
 func bumpVersion(repoRoot, class string) (string, error) {
 	path := filepath.Join(repoRoot, "blindpay.go")
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func bumpVersion(repoRoot, class string) (string, error) {
 	out = append(out, newLine...)
 	out = append(out, data[loc[1]:]...)
 
-	if err := os.WriteFile(path, out, 0o644); err != nil {
+	if err := os.WriteFile(path, out, 0o600); err != nil { //#nosec G703 -- path is repoRoot/blindpay.go, repoRoot comes from the developer CLI arg
 		return "", err
 	}
 	return newVersion, nil

--- a/cmd/contractcheck/main.go
+++ b/cmd/contractcheck/main.go
@@ -162,7 +162,7 @@ func findRepoRoot() (string, error) {
 // loadSpec returns the set of every object property name that appears
 // anywhere in the spec document, plus the webhook endpoint events enum.
 func loadSpec(path string) (map[string]bool, []string, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,7 +274,7 @@ func extractWebhookEventEnum(doc any) []string {
 }
 
 func loadAllowlist(path string) (map[string]allowEntry, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //#nosec G304 -- path is developer-supplied (CLI arg or repo-relative), this is a local codegen tool
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]allowEntry{}, nil


### PR DESCRIPTION
## Summary
- `os.WriteFile` permissions tightened from 0644 to 0600 in the 4 flagged call sites (G306) - the artifacts are repo files, git does not preserve non-exec mode bits, so this is behavior-neutral
- The 9 "potential file inclusion via variable" findings (G304) annotated with justified `#nosec`: every flagged `os.ReadFile` takes a path built from the developer-supplied `repoRoot` CLI argument or a repo-relative constant. `cmd/apisync` and `cmd/contractcheck` are local codegen/CI tools; no path ever comes from untrusted input
- Also annotated 3 additional findings newer gosec versions raise (G703 path traversal taint, G204 subprocess) with the same rationale, so the repo scans clean end to end

`go build`, `go vet` and `gosec ./cmd/...` all pass (0 issues, 12 justified nosec).

## Context
Resolves the 13 open code security findings in the compliance platform for this repo. Fixing rather than suppressing platform-side since this SDK repo may become public.